### PR TITLE
Add PrivateModeChoiceGroup to select type of taxi

### DIFF
--- a/OJP_ModesSupport.xsd
+++ b/OJP_ModesSupport.xsd
@@ -36,6 +36,7 @@
 		</xs:annotation>
 		<xs:sequence>
 			<xs:element name="Mode" type="IndividualModesEnumeration"/>
+			<xs:group ref="siri:PrivateModeChoiceGroup" minOccurs="0" maxOccurs="unbounded"/>
 			<xs:element name="MaxDistance" type="siri:DistanceType" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>Maximum distance in meters. If given, it restricts the maximum distance of routes with the given mode.</xs:documentation>

--- a/siri_model/siri_modes-v1.1.xsd
+++ b/siri_model/siri_modes-v1.1.xsd
@@ -85,6 +85,7 @@ Rail transport, Roads and road transport
 			<xsd:element ref="TelecabinSubmode"/>
 			<xsd:element ref="RailSubmode"/>
 			<xsd:element ref="WaterSubmode"/>
+			<xsd:element ref="TaxiSubmode"/>
 		</xsd:choice>
 	</xsd:group>
 	<xsd:group name="PrivateModeChoiceGroup">
@@ -108,6 +109,7 @@ Rail transport, Roads and road transport
 			<xsd:element ref="RailSubmode"/>
 			<xsd:element ref="TramSubmode"/>
 			<xsd:element ref="WaterSubmode"/>
+			<xsd:element ref="TaxiSubmode"/>
 		</xsd:choice>
 	</xsd:group>
 	<!-- ======================================================================= -->


### PR DESCRIPTION
At this moment it is possible to select the user wants to take a taxi, but the user is unable to select a specific TaxiSubmode.
It might be better to resolve this using a Mode Group like tas been done for PtMode.