### PR TITLE
Allow NumberOfResultsBefore or NumberOfResultsAfter to be 0

### DIFF
--- a/OJP_JourneySupport.xsd
+++ b/OJP_JourneySupport.xsd
@@ -462,12 +462,12 @@
 			<xs:documentation>parameter to control the number of TRIP results before/after a point in time. May NOT be used when departure time at origin AND arrival time at destination are set</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
-			<xs:element name="NumberOfResultsBefore" type="xs:nonNegativeInteger" minOccurs="0">
+			<xs:element name="NumberOfResultsBefore" type="xs:nonNegativeInteger">
 				<xs:annotation>
 					<xs:documentation>The desired number of trip results before the given time (at origin or destination).</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="NumberOfResultsAfter" type="xs:nonNegativeInteger" minOccurs="0">
+			<xs:element name="NumberOfResultsAfter" type="xs:nonNegativeInteger">
 				<xs:annotation>
 					<xs:documentation>The desired number of trip results after the given time (at origin or destination).</xs:documentation>
 				</xs:annotation>

--- a/OJP_JourneySupport.xsd
+++ b/OJP_JourneySupport.xsd
@@ -462,12 +462,12 @@
 			<xs:documentation>parameter to control the number of TRIP results before/after a point in time. May NOT be used when departure time at origin AND arrival time at destination are set</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
-			<xs:element name="NumberOfResultsBefore" type="xs:positiveInteger">
+			<xs:element name="NumberOfResultsBefore" type="xs:nonNegativeInteger" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>The desired number of trip results before the given time (at origin or destination).</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="NumberOfResultsAfter" type="xs:positiveInteger">
+			<xs:element name="NumberOfResultsAfter" type="xs:nonNegativeInteger" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>The desired number of trip results after the given time (at origin or destination).</xs:documentation>
 				</xs:annotation>


### PR DESCRIPTION
At this moment the user is forced to select at least one result after even if the user is only interested in one result before.
This commit allows to specify a 0 value, but also allow to omit the element, the system may infer the desired value.