### PR TITLE
Fix validation with xmllint

### DIFF
--- a/OJP.xsd
+++ b/OJP.xsd
@@ -4,7 +4,7 @@
 	<!-- ===Dependencies ======================================= -->
 	<xs:import namespace="http://www.vdv.de/ojp" schemaLocation="OJP_Requests.xsd"/>
 	<!-- ======================================================================= -->
-	<xs:include schemaLocation="siri/siri_base-v2.0.xsd"/>
+	<xs:include schemaLocation="siri/siri_all_framework-v2.0.xsd"/>
 	<!--== SIRI Request include OJP Requests ===================================================================== -->
 	<xs:element name="OJP">
 		<xs:annotation>

--- a/OJP_Common.xsd
+++ b/OJP_Common.xsd
@@ -2,8 +2,7 @@
 <!-- edited with XMLSpy v2015 rel. 3 sp1 (x64) (http://www.altova.com) by Jutta Schmedding (Mentz Datenverarbeitung GmbH) -->
 <xs:schema xmlns="http://www.vdv.de/ojp" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:siri="http://www.siri.org.uk/siri" targetNamespace="http://www.vdv.de/ojp" elementFormDefault="qualified" attributeFormDefault="unqualified">
 	<!-- ===Dependencies ======================================= -->
-	<xs:import namespace="http://www.siri.org.uk/siri" schemaLocation="./siri_model/siri_reference-v2.0.xsd"/>
-	<xs:import namespace="http://www.siri.org.uk/siri" schemaLocation="./siri_model/siri_operator_support-v2.0.xsd"/>
+	<xs:import namespace="http://www.siri.org.uk/siri" schemaLocation="./siri/siri_all_framework-v2.0.xsd"/>
 	<!-- ===========================================================================================================-->
 	<xs:include schemaLocation="OJP_ModesSupport.xsd"/>
 	<xs:include schemaLocation="OJP_FacilitySupport.xsd"/>

--- a/OJP_Fare.xsd
+++ b/OJP_Fare.xsd
@@ -2,7 +2,7 @@
 <!-- edited with XMLSpy v2007 sp2 (http://www.altova.com) by Werner Kohl (Mentz Datenverarbeitung GmbH) -->
 <xs:schema xmlns="http://www.vdv.de/ojp" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:siri="http://www.siri.org.uk/siri" targetNamespace="http://www.vdv.de/ojp" elementFormDefault="qualified" attributeFormDefault="unqualified">
 	<!-- ===Dependencies ======================================= -->
-	<xs:import namespace="http://www.siri.org.uk/siri" schemaLocation="./siri_model/siri_modes-v1.1.xsd"/>
+	<xs:import namespace="http://www.siri.org.uk/siri" schemaLocation="./siri_model/siri_reference-v2.0.xsd"/>
 	<!-- ===========================================================================================================-->
 	<xs:include schemaLocation="OJP_Common.xsd"/>
 	<xs:include schemaLocation="OJP_FareSupport.xsd"/>

--- a/OJP_ModesSupport.xsd
+++ b/OJP_ModesSupport.xsd
@@ -2,7 +2,7 @@
 <!-- edited with XMLSpy v2015 rel. 3 sp1 (x64) (http://www.altova.com) by Jutta Schmedding (Mentz Datenverarbeitung GmbH) -->
 <xs:schema xmlns="http://www.vdv.de/ojp" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:siri="http://www.siri.org.uk/siri" targetNamespace="http://www.vdv.de/ojp" elementFormDefault="qualified" attributeFormDefault="unqualified">
 	<!-- ===Dependencies ======================================= -->
-	<xs:import namespace="http://www.siri.org.uk/siri" schemaLocation="./siri_model/siri_modes-v1.1.xsd"/>
+	<xs:import namespace="http://www.siri.org.uk/siri" schemaLocation="./siri/siri_all_framework-v2.0.xsd"/>
 	<!-- ===========================================================================================================-->
 	<xs:include schemaLocation="OJP_Utility.xsd"/>
 	<xs:annotation>

--- a/OJP_Requests.xsd
+++ b/OJP_Requests.xsd
@@ -2,7 +2,7 @@
 <!-- edited with XMLSpy v2016 rel. 2 sp1 (x64) (http://www.altova.com) by Christophe Duquesne (Aurige) -->
 <xs:schema xmlns="http://www.vdv.de/ojp" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.vdv.de/ojp" elementFormDefault="qualified" attributeFormDefault="unqualified" id="OJP_siri_service">
 	<!-- ===Dependencies ======================================= -->
-	<xs:import namespace="http://www.siri.org.uk/siri" schemaLocation="./siri/siri_requests-v2.0.xsd"/>
+	<xs:import namespace="http://www.siri.org.uk/siri" schemaLocation="./siri/siri_all_framework-v2.0.xsd"/>
 	<!-- ===OJP Services ======================================= -->
 	<xs:include schemaLocation="OJP_Fare.xsd"/>
 	<xs:include schemaLocation="OJP_Locations.xsd"/>

--- a/OJP_SituationSupport.xsd
+++ b/OJP_SituationSupport.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- edited with XMLSpy v2007 sp2 (http://www.altova.com) by Werner Kohl (Mentz Datenverarbeitung GmbH) -->
 <xs:schema xmlns="http://www.vdv.de/ojp" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:siri="http://www.siri.org.uk/siri" targetNamespace="http://www.vdv.de/ojp" elementFormDefault="qualified" attributeFormDefault="unqualified">
-	<xs:import namespace="http://www.siri.org.uk/siri" schemaLocation="./siri_model/siri_all_situation-v2.0.xsd"/>
+	<xs:import namespace="http://www.siri.org.uk/siri" schemaLocation="./siri/siri_all_framework-v2.0.xsd"/>
 	<xs:complexType name="SituationsStructure">
 		<xs:annotation>
 			<xs:documentation>Wrapper type for SIRI PtSituationsElementStructure</xs:documentation>

--- a/siri/siri_all_framework-v2.0.xsd
+++ b/siri/siri_all_framework-v2.0.xsd
@@ -9,4 +9,10 @@
 	<xsd:include schemaLocation="siri_common_services-v2.0.xsd"/>
 	<xsd:include schemaLocation="siri_request_errorConditions-v2.0.xsd"/>
 	<xsd:include schemaLocation="siri_requests-v2.0.xsd"/>
+	<xsd:include schemaLocation="../siri_model/siri_modes-v1.1.xsd"/>
+	<xsd:include schemaLocation="../siri_model/siri_facilities-v1.2.xsd"/>
+	<xsd:include schemaLocation="../siri_model/siri_operator_support-v2.0.xsd"/>
+	<xsd:include schemaLocation="../siri_model/siri_reference-v2.0.xsd"/>
+	<xsd:include schemaLocation="../siri_model/siri_feature_support-v2.0.xsd"/>
+	<xsd:include schemaLocation="../siri_model/siri_situation-v2.0.xsd"/>
 </xsd:schema>

--- a/xml/xml.xsd
+++ b/xml/xml.xsd
@@ -1,0 +1,108 @@
+<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.w3.org/XML/1998/namespace" xml:lang="en">
+	<xs:annotation>
+		<xs:documentation>
+   See http://www.w3.org/XML/1998/namespace.html and
+   http://www.w3.org/TR/REC-xml for information about this namespace.
+
+    This schema document describes the XML namespace, in a form
+    suitable for import by other schema documents.  
+
+    Note that local names in this namespace are intended to be defined
+    only by the World Wide Web Consortium or its subgroups.  The
+    following names are currently defined in this namespace and should
+    not be used with conflicting semantics by any Working Group,
+    specification, or document instance:
+
+    base (as an attribute name): denotes an attribute whose value
+         provides a URI to be used as the base for interpreting any
+         relative URIs in the scope of the element on which it
+         appears; its value is inherited.  This name is reserved
+         by virtue of its definition in the XML Base specification.
+
+    lang (as an attribute name): denotes an attribute whose value
+         is a language code for the natural language of the content of
+         any element; its value is inherited.  This name is reserved
+         by virtue of its definition in the XML specification.
+  
+    space (as an attribute name): denotes an attribute whose
+         value is a keyword indicating what whitespace processing
+         discipline is intended for the content of the element; its
+         value is inherited.  This name is reserved by virtue of its
+         definition in the XML specification.
+
+    Father (in any context at all): denotes Jon Bosak, the chair of 
+         the original XML Working Group.  This name is reserved by 
+         the following decision of the W3C XML Plenary and 
+         XML Coordination groups:
+
+             In appreciation for his vision, leadership and dedication
+             the W3C XML Plenary on this 10th day of February, 2000
+             reserves for Jon Bosak in perpetuity the XML name
+             xml:Father
+  </xs:documentation>
+	</xs:annotation>
+	<xs:annotation>
+		<xs:documentation>This schema defines attributes and an attribute group
+        suitable for use by
+        schemas wishing to allow xml:base, xml:lang or xml:space attributes
+        on elements they define.
+
+        To enable this, such a schema must import this schema
+        for the XML namespace, e.g. as follows:
+        &lt;schema . . .&gt;
+         . . .
+         &lt;import namespace="http://www.w3.org/XML/1998/namespace"
+                    schemaLocation="http://www.w3.org/2001/03/xml.xsd"/&gt;
+
+        Subsequently, qualified reference to any of the attributes
+        or the group defined below will have the desired effect, e.g.
+
+        &lt;type . . .&gt;
+         . . .
+         &lt;attributeGroup ref="xml:specialAttrs"/&gt;
+ 
+         will define a type which will schema-validate an instance
+         element with any of those attributes</xs:documentation>
+	</xs:annotation>
+	<xs:annotation>
+		<xs:documentation>In keeping with the XML Schema WG's standard versioning
+   policy, this schema document will persist at
+   http://www.w3.org/2001/03/xml.xsd.
+   At the date of issue it can also be found at
+   http://www.w3.org/2001/xml.xsd.
+   The schema document at that URI may however change in the future,
+   in order to remain compatible with the latest version of XML Schema
+   itself.  In other words, if the XML Schema namespace changes, the version
+   of this document at
+   http://www.w3.org/2001/xml.xsd will change
+   accordingly; the version at
+   http://www.w3.org/2001/03/xml.xsd will not change.
+  </xs:documentation>
+	</xs:annotation>
+	<xs:attribute name="lang" type="xs:language">
+		<xs:annotation>
+			<xs:documentation>In due course, we should install the relevant ISO 2- and 3-letter
+         codes as the enumerated possible values . . .</xs:documentation>
+		</xs:annotation>
+	</xs:attribute>
+	<xs:attribute name="space" default="preserve">
+		<xs:simpleType>
+			<xs:restriction base="xs:NCName">
+				<xs:enumeration value="default"/>
+				<xs:enumeration value="preserve"/>
+			</xs:restriction>
+		</xs:simpleType>
+	</xs:attribute>
+	<xs:attribute name="base" type="xs:anyURI">
+		<xs:annotation>
+			<xs:documentation>See http://www.w3.org/TR/xmlbase/ for
+                     information about this attribute.</xs:documentation>
+		</xs:annotation>
+	</xs:attribute>
+	<xs:attributeGroup name="specialAttrs">
+		<xs:attribute ref="xml:base"/>
+		<xs:attribute ref="xml:lang"/>
+		<xs:attribute ref="xml:space"/>
+	</xs:attributeGroup>
+</xs:schema>


### PR DESCRIPTION
At this moment OJP based XML documents cannot be validated using xmllint.
This commit adds the required imports so the tool does function.