### PR TITLE
TransferLimit should be a xs:nonNegativeInteger

### DIFF
--- a/OJP_Trips.xsd
+++ b/OJP_Trips.xsd
@@ -103,7 +103,7 @@
 		</xs:annotation>
 		<xs:sequence>
 			<xs:group ref="BaseTripPolicyGroup"/>
-			<xs:element name="TransferLimit" type="xs:positiveInteger" minOccurs="0">
+			<xs:element name="TransferLimit" type="xs:nonNegativeInteger" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>The maximum number of interchanges the user will accept per trip.</xs:documentation>
 				</xs:annotation>


### PR DESCRIPTION
Rationale a user might want to request a trip with 0 transfers.
And the TripStructure/Transfers is also a xs:nonNegativeInteger

Thanks @comlaterra for spotting this.