### PR TITLE
Allow StopPoint information in LegIntermediate

### DIFF
--- a/OJP_LocationSupport.xsd
+++ b/OJP_LocationSupport.xsd
@@ -13,12 +13,7 @@
 			<xs:documentation>A stop point with id and name</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
-			<xs:element ref="siri:StopPointRef"/>
-			<xs:element name="StopPointName" type="InternationalTextStructure">
-				<xs:annotation>
-					<xs:documentation>Name or description of stop point for use in passenger information.</xs:documentation>
-				</xs:annotation>
-			</xs:element>
+			<xs:element ref="PlaceRefStructure"/>
 			<xs:element name="NameSuffix" type="InternationalTextStructure" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>Additional description of the stop point that may be appended to the name if enough space is available. F.e. "opposite main entrance".</xs:documentation>

--- a/OJP_LocationSupport.xsd
+++ b/OJP_LocationSupport.xsd
@@ -20,7 +20,7 @@
 			</xs:element>
 			<xs:element name="NameSuffix" type="InternationalTextStructure" minOccurs="0">
 				<xs:annotation>
-					<xs:documentation>Additional description of the stop point that may be appended to the name if enough space is available. F.e. "opposite main entrance".</xs:documentation>
+					<xs:documentation>Additional description of the stop point (or stop place) that may be appended to the name if enough space is available. F.e. "opposite main entrance".</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="PlannedQuay" type="InternationalTextStructure" minOccurs="0">

--- a/OJP_LocationSupport.xsd
+++ b/OJP_LocationSupport.xsd
@@ -15,7 +15,7 @@
 		<xs:sequence>
 			<xs:element name="PlaceRef" type="PlaceRefStructure">
 				 <xs:annotation>
-					<xs:documentation>Name or description of stop point (or similar) for use in passenger information.</xs:documentation>
+					<xs:documentation>Stop point (or stop place) for use in passenger information.</xs:documentation>
 				 </xs:annotation>
 			</xs:element>
 			<xs:element name="NameSuffix" type="InternationalTextStructure" minOccurs="0">

--- a/OJP_LocationSupport.xsd
+++ b/OJP_LocationSupport.xsd
@@ -13,7 +13,11 @@
 			<xs:documentation>A stop point with id and name</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
-			<xs:element ref="PlaceRefStructure"/>
+			<xs:element name="PlaceRef" type="PlaceRefStructure">
+				 <xs:annotation>
+					<xs:documentation>Name or description of stop point (or similar) for use in passenger information.</xs:documentation>
+				 </xs:annotation>
+			</xs:element>
 			<xs:element name="NameSuffix" type="InternationalTextStructure" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>Additional description of the stop point that may be appended to the name if enough space is available. F.e. "opposite main entrance".</xs:documentation>


### PR DESCRIPTION
Allow a reference to a `StopPlace` in a `StopPointGroup` instead of having it fixed as `StopPoint` by removing `StopPointName` and changing the reference from `StopPointRef` to `PlaceRef `.
This allows to show information from the `StopPointGroup` even if e.g. the definitive `StopPoint` assignment does not happen until a vehicle arrives at a platform.