### PR TITLE
Added ReferredSystemId in TopographicPlaceStructure

### DIFF
--- a/OJP_LocationSupport.xsd
+++ b/OJP_LocationSupport.xsd
@@ -184,7 +184,7 @@
 			</xs:element>
 			<xs:element name="ReferredSystemId" type="xs:normalizedString" minOccurs="0">
 				<xs:annotation>
-					<xs:documentation>If set, this topographic place resides within the given system. This system can be queried for actual locations within this topographic place. This is used in an distributed environment for a two-steps place identification.</xs:documentation>
+					<xs:documentation>Used in distributed environments (e.g. EU-Spirit). If set, this topographic place resides within the given system (in EU-Spirit "passive server"). This system can be queried for actual locations within this topographic place. This is used in an distributed environment for a two-steps place identification. In EU-Spirit the system IDs were previously called "provider code". See https://eu-spirit.eu/</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="Area" minOccurs="0">

--- a/OJP_LocationSupport.xsd
+++ b/OJP_LocationSupport.xsd
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- edited with XMLSpy v2016 rel. 2 sp1 (x64) (http://www.altova.com) by Christophe Duquesne (Aurige) -->
 <xs:schema xmlns="http://www.vdv.de/ojp" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:siri="http://www.siri.org.uk/siri" targetNamespace="http://www.vdv.de/ojp" elementFormDefault="qualified" attributeFormDefault="unqualified">
 	<!-- ===Dependencies ======================================= -->
 	<xs:import namespace="http://www.siri.org.uk/siri" schemaLocation="./siri_model/siri_modes-v1.1.xsd"/>
@@ -181,6 +180,11 @@
 			<xs:element name="ParentRef" type="TopographicPlaceRefStructure" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>Reference to a parent TopographicPlace.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ReferredSystemId" type="xs:normalizedString" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>If set, this topographic place resides within the given system. This system can be queried for actual locations within this topographic place. This is used in an distributed environment for a two-steps place identification.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="Area" minOccurs="0">


### PR DESCRIPTION
In an distributed environment, the process of place identification can be a two-steps process. In the first step, a topographic place (e.g. city, municipality) is identified from the user's input. In the second step, the system related to the topographic place is queried for places. In order to do so, the topographic places from the first step need to carry the information, to which system they relate.