### PR TITLE
add TravisCI and xmllint scripts for automated checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: minimal
+
+before_script:
+  - sudo apt-get install -qq libxml2-utils
+
+script:
+  - bash .travis/xmllint-check.sh
+
+after_script:
+  - bash .travis/travis-ci_git-commit.sh

--- a/.travis/travis-ci_git-commit.sh
+++ b/.travis/travis-ci_git-commit.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# function to make a commit on a branch in a Travis CI build
+# be sure to avoid creating a Travis CI fork bomb
+# see https://gist.github.com/mitchellkrogza/a296ab5102d7e7142cc3599fca634203 and https://github.com/travis-ci/travis-ci/issues/1701
+function travis-branch-commit() {
+    local head_ref branch_ref
+    head_ref=$(git rev-parse HEAD)
+    if [[ $? -ne 0 || ! $head_ref ]]; then
+        err "failed to get HEAD reference"
+        return 1
+    fi
+    branch_ref=$(git rev-parse "$TRAVIS_BRANCH")
+    if [[ $? -ne 0 || ! $branch_ref ]]; then
+        err "failed to get $TRAVIS_BRANCH reference"
+        return 1
+    fi
+    if [[ $head_ref != $branch_ref ]]; then
+        msg "HEAD ref ($head_ref) does not match $TRAVIS_BRANCH ref ($branch_ref)"
+        msg "Someone may have pushed new commits before this build cloned the repo"
+        return 0
+    fi
+    if ! git checkout "$TRAVIS_BRANCH"; then
+        err "failed to checkout $TRAVIS_BRANCH"
+        return 1
+    fi
+
+    if ! git add --all .; then
+        err "failed to add modified files to git index"
+        return 1
+    fi
+    # make Travis CI skip this build
+    if ! git commit -m "Travis CI update [skip ci]"; then
+        err "failed to commit updates"
+        return 1
+    fi
+    # add to your .travis.yml: `branches\n  except:\n  - "/\\+travis\\d+$/"\n`
+    local git_tag=SOME_TAG_TRAVIS_WILL_NOT_BUILD+travis$TRAVIS_BUILD_NUMBER
+    if ! git tag "$git_tag" -m "Generated tag from Travis CI build $TRAVIS_BUILD_NUMBER"; then
+        err "failed to create git tag: $git_tag"
+        return 1
+    fi
+    local remote=origin
+    if [[ $GH_TOKEN ]]; then
+        remote=https://$GH_TOKEN@github.com/$GH_REPO
+    fi
+    if [[ $TRAVIS_BRANCH != master ]]; then
+        msg "not pushing updates to branch $TRAVIS_BRANCH"
+        return 0
+    fi
+    if ! git push --quiet --follow-tags "$remote" "$TRAVIS_BRANCH" > /dev/null 2>&1; then
+        err "failed to push git changes"
+        return 1
+    fi
+}
+
+function msg() {
+    echo "travis-commit: $*"
+}
+
+function err() {
+    msg "$*" 1>&2
+}
+
+travis-branch-commit

--- a/.travis/xmllint-check.sh
+++ b/.travis/xmllint-check.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+/usr/bin/find . -name "*.xsd" -type f | while read i; do XMLLINT_INDENT=" " xmllint --pretty 1 "$i" > "$i.pretty"; mv "$i.pretty" "$i"; done; /usr/bin/find . -name "*.xml" -type f | while read i; do XMLLINT_INDENT=" " xmllint --pretty 1 "$i" > "$i.pretty"; mv "$i.pretty" "$i"; done; /usr/bin/find . -name "*.wsdl" -type f | while read i; do XMLLINT_INDENT=" " xmllint --pretty 1 "$i" > "$i.pretty"; mv "$i.pretty" "$i"; done;
+echo "finished formatting"
+# xmllint --noout --schema OJP.xsd examples/subdirectory1/*xml examples/subdirectory2/*xml


### PR DESCRIPTION
Add scripts for TravisCI functionality:
- check of xml syntax via xmllint
- possible checks of schema files via validation of standard examples (commented out because I don't have any OJP examples yet)
- TravisCI pushes back its changes