### PR TITLE
Omit unsused requests and responses

### DIFF
--- a/OJP_Fare.xsd
+++ b/OJP_Fare.xsd
@@ -9,7 +9,6 @@
 	<xs:annotation>
 		<xs:documentation>====================================================Request definitions====================================================</xs:documentation>
 	</xs:annotation>
-	<xs:element name="FareRequest" type="FareRequestStructure"/>
 	<xs:group name="FareRequestGroup">
 		<xs:annotation>
 			<xs:documentation>Fare request structure.</xs:documentation>
@@ -44,15 +43,6 @@
 			</xs:element>
 		</xs:sequence>
 	</xs:group>
-	<xs:complexType name="FareRequestStructure">
-		<xs:annotation>
-			<xs:documentation>Fare request element.</xs:documentation>
-		</xs:annotation>
-		<xs:sequence>
-			<xs:group ref="FareRequestGroup"/>
-			<xs:element name="Extension" type="xs:anyType" minOccurs="0"/>
-		</xs:sequence>
-	</xs:complexType>
 	<xs:complexType name="StopFareRequestStructure">
 		<xs:annotation>
 			<xs:documentation>Sub-request: stop-related fare information.</xs:documentation>
@@ -106,16 +96,6 @@
 	<xs:annotation>
 		<xs:documentation>====================================================Response definitions====================================================</xs:documentation>
 	</xs:annotation>
-	<xs:element name="FareResponse">
-		<xs:annotation>
-			<xs:documentation>Fare response element.</xs:documentation>
-		</xs:annotation>
-		<xs:complexType>
-			<xs:complexContent>
-				<xs:extension base="FareResponseStructure"/>
-			</xs:complexContent>
-		</xs:complexType>
-	</xs:element>
 	<xs:group name="FareResponseGroup">
 		<xs:sequence>
 			<xs:element name="FareResult" type="FareResultStructure" minOccurs="0" maxOccurs="unbounded">
@@ -125,19 +105,6 @@
 			</xs:element>
 		</xs:sequence>
 	</xs:group>
-	<xs:complexType name="FareResponseStructure">
-		<xs:annotation>
-			<xs:documentation>Fare response structure.</xs:documentation>
-		</xs:annotation>
-		<xs:sequence>
-			<xs:element name="ErrorMessage" type="ErrorMessageStructure" minOccurs="0" maxOccurs="unbounded">
-				<xs:annotation>
-					<xs:documentation>Error messages related to the request as a whole.</xs:documentation>
-				</xs:annotation>
-			</xs:element>
-			<xs:group ref="FareResponseGroup"/>
-		</xs:sequence>
-	</xs:complexType>
 	<xs:complexType name="FareResultStructure">
 		<xs:annotation>
 			<xs:documentation>Wrapper element for Fare results.</xs:documentation>

--- a/OJP_Locations.xsd
+++ b/OJP_Locations.xsd
@@ -318,7 +318,7 @@
 					<xs:documentation>Rough estimate of the travel duration from the specified location to this exchange point.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="WaitDuration" type="xs:duration" default="PT0M" minOccurs="0">
+			<xs:element name="WaitDuration" type="xs:duration" minOccurs="0" default="PT0M">
 				<xs:annotation>
 					<xs:documentation>Duration needed at this exchange point to change from one service to another. If a journey planning orchestrator puts together a trip at this exchange point, it has to take care, that feeding arrival and fetching departure are at least this duration apart.</xs:documentation>
 				</xs:annotation>

--- a/OJP_Locations.xsd
+++ b/OJP_Locations.xsd
@@ -20,7 +20,6 @@
 	<xs:annotation>
 		<xs:documentation>All functions integrated into one request / response</xs:documentation>
 	</xs:annotation>
-	<xs:element name="LocationInformationRequest" type="LocationInformationRequestStructure"/>
 	<xs:group name="LocationInformationRequestGroup">
 		<xs:sequence>
 			<xs:choice>
@@ -45,13 +44,6 @@
 			</xs:element>
 		</xs:sequence>
 	</xs:group>
-	<xs:complexType name="LocationInformationRequestStructure">
-		<xs:sequence>
-			<xs:group ref="LocationInformationRequestGroup"/>
-			<xs:element name="Extension" type="xs:anyType" minOccurs="0"/>
-		</xs:sequence>
-	</xs:complexType>
-	<xs:element name="LocationInformationResponse" type="LocationInformationResponseStructure"/>
 	<xs:group name="LocationInformationResponseGroup">
 		<xs:sequence>
 			<xs:element name="ContinueAt" type="xs:nonNegativeInteger" minOccurs="0">
@@ -62,12 +54,6 @@
 			<xs:element name="Location" type="PlaceResultStructure" minOccurs="0" maxOccurs="unbounded"/>
 		</xs:sequence>
 	</xs:group>
-	<xs:complexType name="LocationInformationResponseStructure">
-		<xs:sequence>
-			<xs:element name="ErrorMessage" type="ErrorMessageStructure" minOccurs="0" maxOccurs="unbounded"/>
-			<xs:group ref="LocationInformationResponseGroup"/>
-		</xs:sequence>
-	</xs:complexType>
 	<xs:annotation>
 		<xs:documentation>Additional declarations</xs:documentation>
 	</xs:annotation>
@@ -236,7 +222,6 @@
 	<xs:annotation>
 		<xs:documentation>===== Exchange point request ===============================================</xs:documentation>
 	</xs:annotation>
-	<xs:element name="ExchangePointsRequest" type="ExchangePointsRequestStructure"/>
 	<xs:group name="ExchangePointsRequestGroup">
 		<xs:sequence>
 			<xs:element name="PlaceRef" type="PlaceRefStructure" minOccurs="0">
@@ -251,12 +236,6 @@
 			</xs:element>
 		</xs:sequence>
 	</xs:group>
-	<xs:complexType name="ExchangePointsRequestStructure">
-		<xs:sequence>
-			<xs:group ref="ExchangePointsRequestGroup"/>
-			<xs:element name="Extension" type="xs:anyType" minOccurs="0"/>
-		</xs:sequence>
-	</xs:complexType>
 	<xs:complexType name="ExchangePointsParamStructure">
 		<xs:sequence>
 			<xs:group ref="ExchangePointsDataFilterGroup"/>
@@ -317,7 +296,6 @@
 			</xs:element>
 		</xs:sequence>
 	</xs:group>
-	<xs:element name="ExchangePointsResponse" type="ExchangePointsResponseStructure"/>
 	<xs:group name="ExchangePointsResponseGroup">
 		<xs:sequence>
 			<xs:element name="ContinueAt" type="xs:nonNegativeInteger" minOccurs="0">
@@ -328,12 +306,6 @@
 			<xs:element name="Place" type="ExchangePointsResultStructure" minOccurs="0" maxOccurs="unbounded"/>
 		</xs:sequence>
 	</xs:group>
-	<xs:complexType name="ExchangePointsResponseStructure">
-		<xs:sequence>
-			<xs:element name="ErrorMessage" type="ErrorMessageStructure" minOccurs="0" maxOccurs="unbounded"/>
-			<xs:group ref="ExchangePointsResponseGroup"/>
-		</xs:sequence>
-	</xs:complexType>
 	<xs:complexType name="ExchangePointsResultStructure">
 		<xs:sequence>
 			<xs:element name="Place" type="PlaceStructure">
@@ -346,7 +318,7 @@
 					<xs:documentation>Rough estimate of the travel duration from the specified location to this exchange point.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="WaitDuration" type="xs:duration" minOccurs="0" default="PT0M">
+			<xs:element name="WaitDuration" type="xs:duration" default="PT0M" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>Duration needed at this exchange point to change from one service to another. If a journey planning orchestrator puts together a trip at this exchange point, it has to take care, that feeding arrival and fetching departure are at least this duration apart.</xs:documentation>
 				</xs:annotation>


### PR DESCRIPTION
Deleted LocationInformationRequest, LocationInformationResponse, ExchangePointsRequest, ExchangePointsResponse, FareRequest, FareResponse and their respective structure definitions in order to avoid confusion with the actually used request and delivery structures.