### PR TITLE
Replacement of Location with Place

### DIFF
--- a/OJP_JourneySupport.xsd
+++ b/OJP_JourneySupport.xsd
@@ -28,12 +28,12 @@
 		<xs:sequence>
 			<xs:element name="ViaPoint" type="PlaceRefStructure">
 				<xs:annotation>
-					<xs:documentation>Reference to specify the via location.</xs:documentation>
+					<xs:documentation>Reference to specify the via place.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="DwellTime" type="xs:duration" minOccurs="0">
 				<xs:annotation>
-					<xs:documentation>Duration the passenger wants to stay at the via location. Default is 0.</xs:documentation>
+					<xs:documentation>Duration the passenger wants to stay at the via place. Default is 0.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 		</xs:sequence>
@@ -172,9 +172,9 @@
 			<xs:element ref="SituationFullRef" minOccurs="0" maxOccurs="unbounded"/>
 		</xs:sequence>
 	</xs:complexType>
-	<xs:complexType name="TripLocationStructure">
+	<xs:complexType name="TripPlaceStructure">
 		<xs:annotation>
-			<xs:documentation>Location of a passenger currently travelling in a VEHICLE</xs:documentation>
+			<xs:documentation>Place of a passenger currently travelling in a VEHICLE</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
 			<xs:element ref="OperatingDayRef"/>
@@ -403,30 +403,30 @@
 			<xs:choice>
 				<xs:element name="PlaceRef" type="PlaceRefStructure">
 					<xs:annotation>
-						<xs:documentation>Spatial location.</xs:documentation>
+						<xs:documentation>Static place.</xs:documentation>
 					</xs:annotation>
 				</xs:element>
-				<xs:element name="TripLocation" type="TripLocationStructure">
+				<xs:element name="TripPlace" type="TripPlaceStructure">
 					<xs:annotation>
-						<xs:documentation>Location within a (moving) vehicle.</xs:documentation>
+						<xs:documentation>Place within a (moving) vehicle.</xs:documentation>
 					</xs:annotation>
 				</xs:element>
 			</xs:choice>
 			<xs:choice minOccurs="0">
 				<xs:element name="DepArrTime" type="xs:dateTime" minOccurs="0">
 					<xs:annotation>
-						<xs:documentation>Time when departure/arrival from/to location is required.</xs:documentation>
+						<xs:documentation>Time when departure/arrival from/to place is required.</xs:documentation>
 					</xs:annotation>
 				</xs:element>
 				<xs:element name="TimeAllowance" type="xs:duration" minOccurs="0">
 					<xs:annotation>
-						<xs:documentation>Extra time needed before reaching/after leaving this location.</xs:documentation>
+						<xs:documentation>Extra time needed before reaching/after leaving this place.</xs:documentation>
 					</xs:annotation>
 				</xs:element>
 			</xs:choice>
 			<xs:element name="IndividualTransportOptions" type="IndividualTransportOptionsStructure" minOccurs="0" maxOccurs="unbounded">
 				<xs:annotation>
-					<xs:documentation>Options how to access/leave the location by individual transport.</xs:documentation>
+					<xs:documentation>Options how to access/leave the place by individual transport.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 		</xs:sequence>
@@ -438,11 +438,11 @@
 		<xs:sequence>
 			<xs:element name="Places" minOccurs="0">
 				<xs:annotation>
-					<xs:documentation>Container for location objects.</xs:documentation>
+					<xs:documentation>Container for place objects.</xs:documentation>
 				</xs:annotation>
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element name="Location" type="PlaceStructure" maxOccurs="unbounded"/>
+						<xs:element name="Place" type="PlaceStructure" maxOccurs="unbounded"/>
 					</xs:sequence>
 				</xs:complexType>
 			</xs:element>
@@ -608,12 +608,12 @@
 		<xs:sequence>
 			<xs:element name="TrackStart" type="PlaceRefStructure" minOccurs="0">
 				<xs:annotation>
-					<xs:documentation>Start location of this track.</xs:documentation>
+					<xs:documentation>Start place of this track.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="TrackEnd" type="PlaceRefStructure" minOccurs="0">
 				<xs:annotation>
-					<xs:documentation>End location of this track.</xs:documentation>
+					<xs:documentation>End place of this track.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="LinkProjection" minOccurs="0">

--- a/OJP_JourneySupport.xsd
+++ b/OJP_JourneySupport.xsd
@@ -174,7 +174,7 @@
 	</xs:complexType>
 	<xs:complexType name="TripPlaceStructure">
 		<xs:annotation>
-			<xs:documentation>Place of a passenger currently travelling in a VEHICLE</xs:documentation>
+			<xs:documentation>A trip place represents the logical position of a passenger who is currently travelling in a journey service. It can be used similarly to a place (e.g. for trip requests), but it refers always to the current position of the referenced journey service. A trip place does not(!) describe the relative position of a traveller within a vehicle, e.g. the seat.</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
 			<xs:element ref="OperatingDayRef"/>

--- a/OJP_JourneySupport.xsd
+++ b/OJP_JourneySupport.xsd
@@ -174,7 +174,7 @@
 	</xs:complexType>
 	<xs:complexType name="TripPlaceStructure">
 		<xs:annotation>
-			<xs:documentation>A trip place represents the logical position of a passenger who is currently travelling in a journey service. It can be used similarly to a place (e.g. for trip requests), but it refers always to the current position of the referenced journey service. A trip place does not(!) describe the relative position of a traveller within a vehicle, e.g. the seat.</xs:documentation>
+			<xs:documentation>A trip place represents the current logical position of a  journey service. It can be used similarly to a place e.g. for starting a new trip requests from within this service. A trip place does not(!) describe the relative position of a traveller within a vehicle, e.g. the seat.</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
 			<xs:element ref="OperatingDayRef"/>

--- a/OJP_LocationSupport.xsd
+++ b/OJP_LocationSupport.xsd
@@ -184,7 +184,7 @@
 			</xs:element>
 			<xs:element name="ReferredSystemId" type="xs:normalizedString" minOccurs="0">
 				<xs:annotation>
-					<xs:documentation>Used in distributed environments (e.g. EU-Spirit). If set, this topographic place resides within the given system (in EU-Spirit "passive server"). This system can be queried for actual locations within this topographic place. This is used in an distributed environment for a two-steps place identification. In EU-Spirit the system IDs were previously called "provider code". See https://eu-spirit.eu/</xs:documentation>
+					<xs:documentation>Used in distributed environments (e.g. EU-Spirit). If set, this topographic place resides within the given system (in EU-Spirit "passive server"). This system can be queried for actual places within this topographic place. This is used in an distributed environment for a two-steps place identification. In EU-Spirit the system IDs were previously called "provider code". See https://eu-spirit.eu/</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="Area" minOccurs="0">
@@ -289,6 +289,9 @@
 		</xs:sequence>
 	</xs:complexType>
 	<xs:complexType name="PointOfInterestFilterStructure">
+		<xs:annotation>
+			<xs:documentation>Filter POIs by category.</xs:documentation>
+		</xs:annotation>
 		<xs:sequence>
 			<xs:element name="Exclude" type="xs:boolean" default="false" minOccurs="0">
 				<xs:annotation>
@@ -297,7 +300,7 @@
 			</xs:element>
 			<xs:element name="PointOfInterestCategory" type="PointOfInterestCategoryStructure" minOccurs="0" maxOccurs="unbounded">
 				<xs:annotation>
-					<xs:documentation>These can be used to filter POI types of locations even more by additional category filters. If more than one is given the filtering is by logical "OR" (when Exclude=FALSE) and logical "AND" (when Exclude=TRUE).</xs:documentation>
+					<xs:documentation>These POI categories can be used to filter POIs. If more than one is given the filtering is by logical "OR" (when Exclude=FALSE) and logical "AND" (when Exclude=TRUE).</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 		</xs:sequence>
@@ -391,11 +394,11 @@
 		</xs:sequence>
 	</xs:complexType>
 	<xs:annotation>
-		<xs:documentation>========================================= Locations ==============================================</xs:documentation>
+		<xs:documentation>========================================= Places ==============================================</xs:documentation>
 	</xs:annotation>
 	<xs:complexType name="PlaceStructure">
 		<xs:annotation>
-			<xs:documentation> geographic PLACE of any type which may be specified as the origin or destination of a trip</xs:documentation>
+			<xs:documentation>geographic PLACE of any type which may be specified as the origin or destination of a trip</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
 			<xs:choice minOccurs="0">
@@ -411,7 +414,7 @@
 				</xs:element>
 				<xs:element name="TopographicPlace" type="TopographicPlaceStructure">
 					<xs:annotation>
-						<xs:documentation>TopographicPlace, village or city.</xs:documentation>
+						<xs:documentation>TopographicPlace. Region, village, or city.</xs:documentation>
 					</xs:annotation>
 				</xs:element>
 				<xs:element name="PointOfInterest" type="PointOfInterestStructure">
@@ -425,15 +428,15 @@
 					</xs:annotation>
 				</xs:element>
 			</xs:choice>
-			<xs:element name="LocationName" type="InternationalTextStructure">
+			<xs:element name="Name" type="InternationalTextStructure">
 				<xs:annotation>
-					<xs:documentation>Public name of the location.</xs:documentation>
+					<xs:documentation>Public name of the place.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="GeoPosition" type="siri:LocationStructure"/>
 			<xs:element name="Attribute" type="GeneralAttributeStructure" minOccurs="0" maxOccurs="unbounded">
 				<xs:annotation>
-					<xs:documentation>Attribute associated with this location.</xs:documentation>
+					<xs:documentation>Attribute associated with this place.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="Extension" type="xs:anyType" minOccurs="0"/>
@@ -456,9 +459,9 @@
 				<xs:element ref="PointOfInterestRef"/>
 				<xs:element ref="AddressRef"/>
 			</xs:choice>
-			<xs:element name="LocationName" type="InternationalTextStructure">
+			<xs:element name="Name" type="InternationalTextStructure">
 				<xs:annotation>
-					<xs:documentation>Public name of the location.</xs:documentation>
+					<xs:documentation>Public name of the place.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 		</xs:sequence>

--- a/OJP_Locations.xsd
+++ b/OJP_Locations.xsd
@@ -6,7 +6,7 @@
 	<xs:include schemaLocation="OJP_Common.xsd"/>
 	<xs:include schemaLocation="OJP_LocationSupport.xsd"/>
 	<xs:annotation>
-		<xs:documentation>FUNCTION 1: Location Identification</xs:documentation>
+		<xs:documentation>FUNCTION 1: Place Identification</xs:documentation>
 	</xs:annotation>
 	<xs:annotation>
 		<xs:documentation>FUNCTION 2: Object Information</xs:documentation>
@@ -20,35 +20,35 @@
 	<xs:annotation>
 		<xs:documentation>All functions integrated into one request / response</xs:documentation>
 	</xs:annotation>
-	<xs:group name="LocationInformationRequestGroup">
+	<xs:group name="PlaceInformationRequestGroup">
 		<xs:sequence>
 			<xs:choice>
 				<xs:annotation>
-					<xs:documentation>A location information request either consists of an initial request for locations (by name and/or coordinates, with restrictions), or of an follow up request in which a location object is further refined.</xs:documentation>
+					<xs:documentation>A place information request either consists of an initial request for places (by name and/or coordinates, with restrictions), or of an follow up request in which a place object is further refined.</xs:documentation>
 				</xs:annotation>
-				<xs:element name="InitialInput" type="InitialLocationInputStructure">
+				<xs:element name="InitialInput" type="InitialPlaceInputStructure">
 					<xs:annotation>
-						<xs:documentation>Initial input for the location information request. This input defines what is originally looked for.</xs:documentation>
+						<xs:documentation>Initial input for the place information request. This input defines what is originally looked for.</xs:documentation>
 					</xs:annotation>
 				</xs:element>
 				<xs:element name="PlaceRef" type="PlaceRefStructure">
 					<xs:annotation>
-						<xs:documentation>Location for further refinement. If a location in a previous response was marked as not "complete" it can be refined by putting it here.</xs:documentation>
+						<xs:documentation>Place for further refinement. If a place in a previous response was marked as not "complete" it can be refined by putting it here.</xs:documentation>
 					</xs:annotation>
 				</xs:element>
 			</xs:choice>
 			<xs:element name="Restrictions" type="PlaceParamStructure" minOccurs="0">
 				<xs:annotation>
-					<xs:documentation>E.g. location types (stops, addresses, POIs) or specific location attributes</xs:documentation>
+					<xs:documentation>E.g. place types (stops, addresses, POIs) or specific place attributes</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 		</xs:sequence>
 	</xs:group>
-	<xs:group name="LocationInformationResponseGroup">
+	<xs:group name="PlaceInformationResponseGroup">
 		<xs:sequence>
-			<xs:element name="LocationInformationResponseContext" type="ResponseContextStructure" minOccurs="0">
+			<xs:element name="PlaceInformationResponseContext" type="ResponseContextStructure" minOccurs="0">
 				<xs:annotation>
-					<xs:documentation>Context to hold trip response objects that occur frequently.</xs:documentation>
+					<xs:documentation>Context to hold response objects that occur frequently.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="ContinueAt" type="xs:nonNegativeInteger" minOccurs="0">
@@ -56,32 +56,32 @@
 					<xs:documentation>If the response returns less results than expected, the value of skip can be used in a follow-up request to get further results. It tells the server to skip the given number of results in its response.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="Location" type="PlaceResultStructure" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="PlaceResult" type="PlaceResultStructure" minOccurs="0" maxOccurs="unbounded"/>
 		</xs:sequence>
 	</xs:group>
 	<xs:annotation>
 		<xs:documentation>Additional declarations</xs:documentation>
 	</xs:annotation>
-	<xs:complexType name="InitialLocationInputStructure">
+	<xs:complexType name="InitialPlaceInputStructure">
 		<xs:sequence>
-			<xs:element name="LocationName" type="xs:string" minOccurs="0">
+			<xs:element name="Name" type="xs:string" minOccurs="0">
 				<xs:annotation>
-					<xs:documentation>Name of the location object which is looked after. This is usually the user's input. If not given, the name of the resulting location objects is not relevant.</xs:documentation>
+					<xs:documentation>Name of the place object which is looked after. This is usually the user's input. If not given, the name of the resulting place objects is not relevant.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="GeoPosition" type="siri:LocationStructure" minOccurs="0">
 				<xs:annotation>
-					<xs:documentation>Coordinate where to look for locations. If given, the result should prefer location objects near to this GeoPosition.</xs:documentation>
+					<xs:documentation>Coordinate where to look for places. If given, the result should prefer place objects near to this GeoPosition.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="GeoRestriction" type="GeoRestrictionsStructure" minOccurs="0">
 				<xs:annotation>
-					<xs:documentation>Restricts the resulting location objects to the given geographical area.</xs:documentation>
+					<xs:documentation>Restricts the resulting place objects to the given geographical area.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="AllowedSystemId" type="xs:normalizedString" minOccurs="0" maxOccurs="unbounded">
 				<xs:annotation>
-					<xs:documentation>Used in distributed environments. e.g. EU-Spirit. If none is given, the location information request refers to all known systems (in EU-Spirit "passive servers"). If at least one is given, the location information request refers only to the given systems (in EU-Spirit "passive servers"). In EU-Spirit the system IDs were previously called "provider code". See https://eu-spirit.eu/</xs:documentation>
+					<xs:documentation>Used in distributed environments. e.g. EU-Spirit. If none is given, the place information request refers to all known systems (in EU-Spirit "passive servers"). If at least one is given, the place information request refers only to the given systems (in EU-Spirit "passive servers"). In EU-Spirit the system IDs were previously called "provider code". See https://eu-spirit.eu/</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 		</xs:sequence>
@@ -130,10 +130,10 @@
 	</xs:complexType>
 	<xs:complexType name="PlaceResultStructure">
 		<xs:sequence>
-			<xs:element name="Location" type="PlaceStructure"/>
+			<xs:element name="Place" type="PlaceStructure"/>
 			<xs:element name="Complete" type="xs:boolean">
 				<xs:annotation>
-					<xs:documentation>States whether the included location is complete or needs further refinement. Only complete locations are fully resolved and can be used in e.g. trip requests. Incomplete locations have to be refined entering them once again into a LocationInformationRequest.</xs:documentation>
+					<xs:documentation>States whether the included place is complete or needs further refinement. Only complete places are fully resolved and can be used in e.g. trip requests. Incomplete places have to be refined entering them once again into a PlaceInformationRequest.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="Probability" minOccurs="0">
@@ -147,7 +147,11 @@
 					</xs:restriction>
 				</xs:simpleType>
 			</xs:element>
-			<xs:element name="Mode" type="ModeStructure" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Mode" type="ModeStructure" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>List of transport modes that call at this place object. This list should only be filled in case of stop points or stop places – and only when explicitly requested.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
 		</xs:sequence>
 	</xs:complexType>
 	<xs:group name="PlacePolicyGroup">
@@ -159,7 +163,7 @@
 			</xs:element>
 			<xs:element name="NumberOfResults" type="xs:positiveInteger" minOccurs="0">
 				<xs:annotation>
-					<xs:documentation>Maximum number of results to be returned. The service is allowed to return fewer objects if reasonable or otherwise appropriate. If the number of matching objects is expected to be large (eg: in the case that all objects should be delivered) this parameter can be used to partition the response delivery into smaller chunks. The location information service is expected to support a response volume of at least 500 location objects within one single response.</xs:documentation>
+					<xs:documentation>Maximum number of results to be returned. The service is allowed to return fewer objects if reasonable or otherwise appropriate. If the number of matching objects is expected to be large (eg: in the case that all objects should be delivered) this parameter can be used to partition the response delivery into smaller chunks. The place information service is expected to support a response volume of at least 500 objects within one single response.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="ContinueAt" type="xs:nonNegativeInteger" minOccurs="0">
@@ -178,27 +182,27 @@
 		<xs:sequence>
 			<xs:element name="Type" type="PlaceTypeEnumeration" minOccurs="0" maxOccurs="unbounded">
 				<xs:annotation>
-					<xs:documentation>Allowed location object types. If none is given, all types are allowed.</xs:documentation>
+					<xs:documentation>Allowed place object types. If none is given, all types are allowed.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="Usage" type="PlaceUsageEnumeration" minOccurs="0">
 				<xs:annotation>
-					<xs:documentation>Defines, whether location objects for origin, via, or destination are searched.</xs:documentation>
+					<xs:documentation>Defines, whether place objects for origin, via, or destination are searched.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="PtModes" type="PtModeFilterStructure" minOccurs="0">
 				<xs:annotation>
-					<xs:documentation>Allowed public transport modes. Defines, which public transport modes must be available at the returned location objects. Applies only to stops.</xs:documentation>
+					<xs:documentation>Allowed public transport modes. Defines, which public transport modes must be available at the returned place objects. Applies only to stops.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="OperatorFilter" type="OperatorFilterStructure" minOccurs="0">
 				<xs:annotation>
-					<xs:documentation>Filter for locations that are operated by certain organisations.</xs:documentation>
+					<xs:documentation>Filter for places that are operated by certain organisations.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="TopographicPlaceRef" type="TopographicPlaceRefStructure" minOccurs="0" maxOccurs="unbounded">
 				<xs:annotation>
-					<xs:documentation>If at least one is set, only location objects within the given localities are allowed.</xs:documentation>
+					<xs:documentation>If at least one is set, only place objects within the given localities are allowed.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="PointOfInterestFilter" type="PointOfInterestFilterStructure" minOccurs="0">
@@ -231,12 +235,12 @@
 		<xs:sequence>
 			<xs:element name="PlaceRef" type="PlaceRefStructure" minOccurs="0">
 				<xs:annotation>
-					<xs:documentation>Location for which exchange points to other "neighbour" systems are to be searched. This location is usually the origin/destination of a passenger journey. May be omitted if all exchange points shall be returned.</xs:documentation>
+					<xs:documentation>Place for which exchange points to other "neighbour" systems are to be searched. This place is usually the origin/destination of a passenger journey. May be omitted if all exchange points shall be returned.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="Params" type="ExchangePointsParamStructure" minOccurs="0">
 				<xs:annotation>
-					<xs:documentation>E.g. location types (stops, addresses, POIs) or specific location attributes</xs:documentation>
+					<xs:documentation>E.g. place types (stops, addresses, POIs) or specific place attributes</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 		</xs:sequence>
@@ -251,27 +255,27 @@
 		<xs:sequence>
 			<xs:element name="Type" type="PlaceTypeEnumeration" minOccurs="0" maxOccurs="unbounded">
 				<xs:annotation>
-					<xs:documentation>Allowed location object types. If none is given, all types are allowed.</xs:documentation>
+					<xs:documentation>Allowed place object types. If none is given, all types are allowed.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="Usage" type="PlaceUsageEnumeration" minOccurs="0">
 				<xs:annotation>
-					<xs:documentation>Defines, whether the location object of this request acts as origin, via or destination point of the passenger journey.</xs:documentation>
+					<xs:documentation>Defines, whether the place object of this request acts as origin, via or destination point of the passenger journey.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="PtModes" type="PtModeFilterStructure" minOccurs="0">
 				<xs:annotation>
-					<xs:documentation>Allowed public transport modes. Defines, which public transport modes must be available at the returned location objects. Applies only to stops.</xs:documentation>
+					<xs:documentation>Allowed public transport modes. Defines, which public transport modes must be available at the returned place objects. Applies only to stops.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="OperatorFilter" type="OperatorFilterStructure" minOccurs="0">
 				<xs:annotation>
-					<xs:documentation>Filter for locations that are operated by certain organisations.</xs:documentation>
+					<xs:documentation>Filter for places that are operated by certain organisations.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="TopographicPlaceRef" type="TopographicPlaceRefStructure" minOccurs="0" maxOccurs="unbounded">
 				<xs:annotation>
-					<xs:documentation>If at least one is set, only location objects within the given localities are allowed.</xs:documentation>
+					<xs:documentation>If at least one is set, only place objects within the given localities are allowed.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="DestinationSystem" type="siri:ParticipantRefStructure" minOccurs="0">
@@ -325,7 +329,7 @@
 			</xs:element>
 			<xs:element name="TravelDurationEstimate" type="xs:duration" minOccurs="0">
 				<xs:annotation>
-					<xs:documentation>Rough estimate of the travel duration from the specified location to this exchange point.</xs:documentation>
+					<xs:documentation>Rough estimate of the travel duration from the specified refrence place to this exchange point.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="WaitDuration" type="xs:duration" minOccurs="0" default="PT0M">
@@ -340,7 +344,7 @@
 			</xs:element>
 			<xs:element name="Mode" type="ModeStructure" minOccurs="0" maxOccurs="unbounded">
 				<xs:annotation>
-					<xs:documentation>List of transport modes that call at this location object. This list should only be filled in case of stop points or stop places – and only when explicitly requested.</xs:documentation>
+					<xs:documentation>List of transport modes that call at this place object. This list should only be filled in case of stop points or stop places – and only when explicitly requested.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 		</xs:sequence>

--- a/OJP_Requests.xsd
+++ b/OJP_Requests.xsd
@@ -36,27 +36,27 @@
 			</xs:extension>
 		</xs:complexContent>
 	</xs:complexType>
-	<!-- ==== LocationInformation Service=============================================== -->
-	<xs:element name="OJPLocationInformationRequest" type="OJPLocationInformationRequestStructure" substitutionGroup="siri:AbstractFunctionalServiceRequest"/>
-	<xs:complexType name="OJPLocationInformationRequestStructure">
+	<!-- ==== PlaceInformation Service=============================================== -->
+	<xs:element name="OJPPlaceInformationRequest" type="OJPPlaceInformationRequestStructure" substitutionGroup="siri:AbstractFunctionalServiceRequest"/>
+	<xs:complexType name="OJPPlaceInformationRequestStructure">
 		<xs:complexContent>
 			<xs:extension base="AbstractOJPServiceRequestStructure">
 				<xs:sequence>
-					<xs:group ref="LocationInformationRequestGroup"/>
+					<xs:group ref="PlaceInformationRequestGroup"/>
 					<xs:element ref="siri:Extensions" minOccurs="0"/>
 				</xs:sequence>
 			</xs:extension>
 		</xs:complexContent>
 	</xs:complexType>
 	<!-- ======================================================================= -->
-	<xs:element name="OJPLocationInformationDelivery" type="OJPLocationInformationDeliveryStructure" substitutionGroup="siri:AbstractFunctionalServiceDelivery"/>
-	<xs:complexType name="OJPLocationInformationDeliveryStructure">
+	<xs:element name="OJPPlaceInformationDelivery" type="OJPPlaceInformationDeliveryStructure" substitutionGroup="siri:AbstractFunctionalServiceDelivery"/>
+	<xs:complexType name="OJPPlaceInformationDeliveryStructure">
 		<xs:complexContent>
 			<xs:extension base="siri:AbstractServiceDeliveryStructure">
 				<xs:sequence>
-					<xs:element ref="OJPLocationInformationRequest" minOccurs="0"/>
+					<xs:element ref="OJPPlaceInformationRequest" minOccurs="0"/>
 					<xs:group ref="ServiceResponseContextGroup"/>
-					<xs:group ref="LocationInformationResponseGroup"/>
+					<xs:group ref="PlaceInformationResponseGroup"/>
 					<xs:element ref="siri:Extensions" minOccurs="0"/>
 				</xs:sequence>
 			</xs:extension>

--- a/OJP_StopEvents.xsd
+++ b/OJP_StopEvents.xsd
@@ -10,9 +10,9 @@
 			<xs:documentation>Request structure for departure and arrival events at stops</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
-			<xs:element name="Location" type="PlaceContextStructure">
+			<xs:element name="Place" type="PlaceContextStructure">
 				<xs:annotation>
-					<xs:documentation>Location for which to obtain stop event information.</xs:documentation>
+					<xs:documentation>Place for which to obtain stop event information.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="Params" type="StopEventParamStructure" minOccurs="0">
@@ -66,7 +66,7 @@
 			</xs:element>
 			<xs:element name="TimeWindow" type="xs:duration" minOccurs="0">
 				<xs:annotation>
-					<xs:documentation>Time window events should lie within. Starting from time  given in LocationContext.</xs:documentation>
+					<xs:documentation>Time window events should lie within. Starting from time given in PlaceContext.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="StopEventType" type="StopEventTypeEnumeration" minOccurs="0">
@@ -196,12 +196,12 @@
 			</xs:element>
 			<xs:element name="WalkDistance" type="siri:DistanceType" minOccurs="0">
 				<xs:annotation>
-					<xs:documentation>Distance from request location (f.e. address) to this stop in metres.</xs:documentation>
+					<xs:documentation>Distance from request place (f.e. address) to this stop in metres.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="WalkDuration" type="xs:duration" minOccurs="0">
 				<xs:annotation>
-					<xs:documentation>Distance from request location (f.e. address) to this stop in seconds. All user options taken into account (f.e. walk speed).</xs:documentation>
+					<xs:documentation>Walking duration from request place (f.e. address) to this stop. All user options taken into account (f.e. walk speed).</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 		</xs:sequence>


### PR DESCRIPTION
According to TRANSMODEL a location is only a geographical position, while a place has a location along with other attributes. Within OJP the two terms were used inconsistently. This commit distinguishes the two terms properly. In most cases the term location was replaced by the term place. This applies to type and element names but also to annotations. This commit addresses issue #44.