### PR TITLE
Optional PublishedLineName

### DIFF
--- a/OJP_JourneySupport.xsd
+++ b/OJP_JourneySupport.xsd
@@ -58,7 +58,7 @@
 					<xs:documentation>[a specialisation of MODE in TMv6] an extended range of VEHICLE MODEs, aggregating them with some SUBMODEs</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="PublishedLineName" type="InternationalTextStructure">
+			<xs:element name="PublishedLineName" type="InternationalTextStructure" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>Line name or service description as known to the public, f.e. "512", "S8" or "Circle Line".</xs:documentation>
 				</xs:annotation>


### PR DESCRIPTION
In Siri PublishedLineName is optional and in NeTEx all possible equivalent elements in Line are optional as well and even the Ref to al Line in VehicleJourney is optional, so it should be optional here as well. This is alread

https://github.com/VDVde/OJP/issues/71