### PR TITLE
Moved ResponseContextStructure to OJP_RequestSupport.xsd

### DIFF
--- a/OJP_JourneySupport.xsd
+++ b/OJP_JourneySupport.xsd
@@ -475,28 +475,6 @@
 			</xs:element>
 		</xs:sequence>
 	</xs:complexType>
-	<xs:complexType name="ResponseContextStructure">
-		<xs:annotation>
-			<xs:documentation>Abstract structure providing response contexts related to journeys.</xs:documentation>
-		</xs:annotation>
-		<xs:sequence>
-			<xs:element name="Places" minOccurs="0">
-				<xs:annotation>
-					<xs:documentation>Container for place objects. Only place objects that are referenced in the response should be put into the container.</xs:documentation>
-				</xs:annotation>
-				<xs:complexType>
-					<xs:sequence>
-						<xs:element name="Place" type="PlaceStructure" maxOccurs="unbounded"/>
-					</xs:sequence>
-				</xs:complexType>
-			</xs:element>
-			<xs:element name="Situations" type="SituationsStructure" minOccurs="0">
-				<xs:annotation>
-					<xs:documentation>Container for SIRI SX situation objects. Only situations that are referenced in the response should be put into the container.</xs:documentation>
-				</xs:annotation>
-			</xs:element>
-		</xs:sequence>
-	</xs:complexType>
 	<xs:annotation>
 		<xs:documentation>=========================================== Filter Groups ===========================================================</xs:documentation>
 	</xs:annotation>

--- a/OJP_Places.xsd
+++ b/OJP_Places.xsd
@@ -5,6 +5,7 @@
 	<!-- ===========================================================================================================-->
 	<xs:include schemaLocation="OJP_Common.xsd"/>
 	<xs:include schemaLocation="OJP_PlaceSupport.xsd"/>
+	<xs:include schemaLocation="OJP_RequestSupport.xsd"/>
 	<xs:annotation>
 		<xs:documentation>FUNCTION 1: Place Identification</xs:documentation>
 	</xs:annotation>
@@ -332,7 +333,7 @@
 					<xs:documentation>Rough estimate of the travel duration from the specified refrence place to this exchange point.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="WaitDuration" type="xs:duration" minOccurs="0" default="PT0M">
+			<xs:element name="WaitDuration" type="xs:duration" default="PT0M" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>Duration needed at this exchange point to change from one service to another. If a journey planning orchestrator puts together a trip at this exchange point, it has to take care, that feeding arrival and fetching departure are at least this duration apart.</xs:documentation>
 				</xs:annotation>

--- a/OJP_Places.xsd
+++ b/OJP_Places.xsd
@@ -333,7 +333,7 @@
 					<xs:documentation>Rough estimate of the travel duration from the specified refrence place to this exchange point.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="WaitDuration" type="xs:duration" default="PT0M" minOccurs="0">
+			<xs:element name="WaitDuration" type="xs:duration" minOccurs="0" default="PT0M">
 				<xs:annotation>
 					<xs:documentation>Duration needed at this exchange point to change from one service to another. If a journey planning orchestrator puts together a trip at this exchange point, it has to take care, that feeding arrival and fetching departure are at least this duration apart.</xs:documentation>
 				</xs:annotation>

--- a/OJP_RequestSupport.xsd
+++ b/OJP_RequestSupport.xsd
@@ -3,6 +3,8 @@
 	<xs:import namespace="http://www.siri.org.uk/siri" schemaLocation="./siri/siri_all_framework-v2.0.xsd"/>
 	<xs:import namespace="http://www.siri.org.uk/siri" schemaLocation="./siri_model/siri_journey_support-v2.0.xsd"/>
 	<xs:include schemaLocation="OJP_Common.xsd"/>
+	<xs:include schemaLocation="OJP_PlaceSupport.xsd"/>
+	<xs:include schemaLocation="OJP_SituationSupport.xsd"/>
 	<xs:annotation>
 		<xs:documentation>====================================================Simple Types ====================================================</xs:documentation>
 	</xs:annotation>
@@ -148,4 +150,29 @@
 			<xs:group ref="siri:ServiceResponseGroup"/>
 		</xs:sequence>
 	</xs:group>
+	<xs:annotation>
+		<xs:documentation>====================================================Collection contexts====================================================</xs:documentation>
+	</xs:annotation>
+	<xs:complexType name="ResponseContextStructure">
+		<xs:annotation>
+			<xs:documentation>Structure providing response contexts related to journeys, containing collections of places and situations.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="Places" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Container for place objects. Only place objects that are referenced in the response should be put into the container.</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="Place" type="PlaceStructure" maxOccurs="unbounded"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="Situations" type="SituationsStructure" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Container for SIRI SX situation objects. Only situations that are referenced in the response should be put into the container.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
 </xs:schema>

--- a/OJP_StopEvents.xsd
+++ b/OJP_StopEvents.xsd
@@ -5,6 +5,7 @@
 	<!-- ===========================================================================================================-->
 	<xs:include schemaLocation="OJP_Common.xsd"/>
 	<xs:include schemaLocation="OJP_JourneySupport.xsd"/>
+	<xs:include schemaLocation="OJP_RequestSupport.xsd"/>
 	<xs:group name="StopEventRequestGroup">
 		<xs:annotation>
 			<xs:documentation>Request structure for departure and arrival events at stops</xs:documentation>

--- a/OJP_TripInfo.xsd
+++ b/OJP_TripInfo.xsd
@@ -2,6 +2,7 @@
 <xs:schema xmlns="http://www.vdv.de/ojp" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.vdv.de/ojp" elementFormDefault="qualified" attributeFormDefault="unqualified">
 	<xs:include schemaLocation="OJP_Common.xsd"/>
 	<xs:include schemaLocation="OJP_JourneySupport.xsd"/>
+	<xs:include schemaLocation="OJP_RequestSupport.xsd"/>
 	<xs:annotation>
 		<xs:documentation>===================== Request structures ============================================================</xs:documentation>
 	</xs:annotation>

--- a/OJP_Trips.xsd
+++ b/OJP_Trips.xsd
@@ -6,6 +6,7 @@
 	<xs:include schemaLocation="OJP_Common.xsd"/>
 	<xs:include schemaLocation="OJP_JourneySupport.xsd"/>
 	<xs:include schemaLocation="OJP_FareSupport.xsd"/>
+	<xs:include schemaLocation="OJP_RequestSupport.xsd"/>
 	<xs:annotation>
 		<xs:documentation>===== Request Structures ===============================================</xs:documentation>
 	</xs:annotation>


### PR DESCRIPTION
OJP_Places.xsd was not well-formed, because it used ResponseContextStructure without including it. Moved ResponseContextStructure from OJP_JourneySupport.xsd to OJP_RequestSupport.xsd, as it is a general structure and not only for journeys. Added includes of OJP_RequestSupport into several files.