### PR TITLE
Consistent use of WebLinkStructure

### DIFF
--- a/OJP/OJP_Common.xsd
+++ b/OJP/OJP_Common.xsd
@@ -334,7 +334,7 @@
 	</xs:annotation>
 	<xs:complexType name="GeneralAttributeStructure">
 		<xs:annotation>
-			<xs:documentation>Structured attribute classification with associated text.</xs:documentation>
+			<xs:documentation>Structured attribute classification with associated text. If URL is given, it refers to the whole attribute text.</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
 			<xs:element name="Text" type="InternationalTextStructure">
@@ -358,11 +358,7 @@
 					<xs:documentation>Importance of the attribute.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="InfoUrl" type="xs:anyURI" minOccurs="0">
-				<xs:annotation>
-					<xs:documentation>URL to additional information on this general attribute. If available, the whole attribute text has to be used as the marked link.</xs:documentation>
-				</xs:annotation>
-			</xs:element>
+			<xs:group ref="WebLinkGroup" minOccurs="0"/>
 		</xs:sequence>
 	</xs:complexType>
 </xs:schema>

--- a/OJP/OJP_Fare.xsd
+++ b/OJP/OJP_Fare.xsd
@@ -224,7 +224,7 @@
 					<xs:documentation>The set of passed zones.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="StaticInfoUrl" type="xs:anyURI" minOccurs="0" maxOccurs="unbounded">
+			<xs:element name="StaticInfoUrl" type="WebLinkStructure" minOccurs="0" maxOccurs="unbounded">
 				<xs:annotation>
 					<xs:documentation>URL to Fare information pages on the web.</xs:documentation>
 				</xs:annotation>

--- a/OJP/OJP_FareSupport.xsd
+++ b/OJP/OJP_FareSupport.xsd
@@ -144,12 +144,12 @@
 					<xs:documentation>Name of the booking agency (contractual partner).</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="BookingUrl" type="xs:anyURI" minOccurs="0">
+			<xs:element name="BookingUrl" type="WebLinkStructure" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>URL to online booking service.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="InfoUrl" type="xs:anyURI" minOccurs="0">
+			<xs:element name="InfoUrl" type="WebLinkStructure" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>URL to information page.</xs:documentation>
 				</xs:annotation>

--- a/OJP/OJP_Utility.xsd
+++ b/OJP/OJP_Utility.xsd
@@ -65,16 +65,11 @@
 			</xs:element>
 		</xs:sequence>
 	</xs:complexType>
-	<xs:complexType name="WebLinkStructure">
+	<xs:group name="WebLinkGroup">
 		<xs:annotation>
-			<xs:documentation>URL of a web resource with label.</xs:documentation>
+			<xs:documentation>URL of a web resource including type of resource.</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
-			<xs:element name="Label" type="InternationalTextStructure">
-				<xs:annotation>
-					<xs:documentation>Label for link description.</xs:documentation>
-				</xs:annotation>
-			</xs:element>
 			<xs:element name="Url" type="xs:anyURI">
 				<xs:annotation>
 					<xs:documentation>URL to resource on web.</xs:documentation>
@@ -90,6 +85,19 @@
 					<xs:documentation>Is the referenced resource meant to be embedded as a webview in a surrounding context, e.g. app or web page? If yes, the resource has to be fully responsive. Default is false.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
+		</xs:sequence>
+	</xs:group>
+	<xs:complexType name="WebLinkStructure">
+		<xs:annotation>
+			<xs:documentation>URL of a web resource with label.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="Label" type="InternationalTextStructure">
+				<xs:annotation>
+					<xs:documentation>Label for link description.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:group ref="WebLinkGroup"/>
 		</xs:sequence>
 	</xs:complexType>
 </xs:schema>


### PR DESCRIPTION
Removed 3 occurrences of xs:anyURI and exchanged it with WebLinkStructure (MultiTripFareResultStructure and BookingArrangementStructure). Introduced a WebLinkGroup consisting of URL, MIME type and embeddedness. Used that group within the WebLinkStructure (without actually changing it). Exchanged xs:anyURI in GeneralAttributeStructure by the WebLinkGroup as there is already a text available for the link.