### PR TITLE
Added AreaStructure and LinkProjectionStructure

### DIFF
--- a/OJP/OJP_Common.xsd
+++ b/OJP/OJP_Common.xsd
@@ -42,6 +42,30 @@
 			</xs:element>
 		</xs:sequence>
 	</xs:complexType>
+	<xs:complexType name="LinkProjectionStructure">
+		<xs:annotation>
+			<xs:documentation>An oriented correspondence from one LINK of a source layer, onto an entity in a target layer: e.g. LINK SEQUENCE.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="Position" type="siri:LocationStructure" minOccurs="2" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Ordered list of locations representing the geogemtry of the link.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="AreaStructure">
+		<xs:annotation>
+			<xs:documentation>Area described as a polygon.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="Points" type="siri:LocationStructure" minOccurs="3" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Ordered list of geographic locations describing the polygon of the area.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
 	<xs:annotation>
 		<xs:documentation>========================================== Participants ==========================================</xs:documentation>
 	</xs:annotation>

--- a/OJP/OJP_JourneySupport.xsd
+++ b/OJP/OJP_JourneySupport.xsd
@@ -625,7 +625,7 @@
 		<xs:sequence>
 			<xs:element name="TrackSection" type="TrackSectionStructure" maxOccurs="unbounded">
 				<xs:annotation>
-					<xs:documentation>LINK PROJECTION on the infrastructure network of the TRIP LEG together with time information</xs:documentation>
+					<xs:documentation>LINK PROJECTION on the infrastructure network of the trip leg section together with time information.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 		</xs:sequence>
@@ -645,15 +645,10 @@
 					<xs:documentation>End place of this track.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="LinkProjection" minOccurs="0">
+			<xs:element name="LinkProjection" type="LinkProjectionStructure" minOccurs="0">
 				<xs:annotation>
-					<xs:documentation>an oriented correspondence from one LINK of a source layer, onto an entity in a target layer: e.g. LINK SEQUENCE, COMPLEX FEATURE, within a defined TYPE OF PROJECTION</xs:documentation>
+					<xs:documentation>An oriented correspondence from one LINK of a source layer, onto an entity in a target layer: e.g. LINK SEQUENCE.</xs:documentation>
 				</xs:annotation>
-				<xs:complexType>
-					<xs:sequence>
-						<xs:element name="Position" type="siri:LocationStructure" minOccurs="2" maxOccurs="unbounded"/>
-					</xs:sequence>
-				</xs:complexType>
 			</xs:element>
 			<xs:element name="RoadName" type="xs:string" minOccurs="0">
 				<xs:annotation>

--- a/OJP/OJP_PlaceSupport.xsd
+++ b/OJP/OJP_PlaceSupport.xsd
@@ -188,15 +188,10 @@
 					<xs:documentation>Used in distributed environments (e.g. EU-Spirit). If set, this topographic place resides within the given system (in EU-Spirit "passive server"). This system can be queried for actual places within this topographic place. This is used in an distributed environment for a two-steps place identification. In EU-Spirit the system IDs were previously called "provider code". See https://eu-spirit.eu/</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="Area" minOccurs="0">
+			<xs:element name="Area" type="AreaStructure" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>Area covered by the locality described as a polygon.</xs:documentation>
 				</xs:annotation>
-				<xs:complexType>
-					<xs:sequence>
-						<xs:element name="Points" type="siri:LocationStructure" minOccurs="3" maxOccurs="unbounded"/>
-					</xs:sequence>
-				</xs:complexType>
 			</xs:element>
 		</xs:sequence>
 	</xs:complexType>

--- a/docs/generated/OJP.adoc
+++ b/docs/generated/OJP.adoc
@@ -681,12 +681,7 @@ The element contains a _sequence_ of the following elements:
 | `PrivateCode` | 0:*  | _PrivateCodeStructure_ | Code of this TopographicPlace in private/foreign/proprietary coding schemes.
 | `ParentRef` | 0:1  | _TopographicPlaceRefStructure_ | Reference to a parent TopographicPlace.
 | `ReferredSystemId` | 0:1  | _xs:normalizedString_ | Used in distributed environments (e.g. EU-Spirit). If set, this topographic place resides within the given system (in EU-Spirit "passive server"). This system can be queried for actual places within this topographic place. This is used in an distributed environment for a two-steps place identification. In EU-Spirit the system IDs were previously called "provider code". See https://eu-spirit.eu/
-| `Area` | 0:1  | Area covered by the locality described as a polygon.
-
-The element contains only one element:
-
-| `Points` | 3:*  | _siri:LocationStructure_ 
-
+| `Area` | 0:1  | _AreaStructure_ | Area covered by the locality described as a polygon.
 |===
 
 
@@ -1779,7 +1774,7 @@ The LINK PROJECTION of a Leg onto the topography of the route being followed.
 
 The element contains only one element:
 
-| `TrackSection` | 1:*  | _TrackSectionStructure_ | LINK PROJECTION on the infrastructure network of the TRIP LEG together with time information
+| `TrackSection` | 1:*  | _TrackSectionStructure_ | LINK PROJECTION on the infrastructure network of the trip leg section together with time information.
 
 
 
@@ -1791,12 +1786,7 @@ The element contains a _sequence_ of the following elements:
 |===
 | `TrackStart` | 0:1  | _PlaceRefStructure_ | Start place of this track.
 | `TrackEnd` | 0:1  | _PlaceRefStructure_ | End place of this track.
-| `LinkProjection` | 0:1  | an oriented correspondence from one LINK of a source layer, onto an entity in a target layer: e.g. LINK SEQUENCE, COMPLEX FEATURE, within a defined TYPE OF PROJECTION
-
-The element contains only one element:
-
-| `Position` | 2:*  | _siri:LocationStructure_ 
-
+| `LinkProjection` | 0:1  | _LinkProjectionStructure_ | An oriented correspondence from one LINK of a source layer, onto an entity in a target layer: e.g. LINK SEQUENCE.
 | `RoadName` | 0:1  | _xs:string_ | Name of the road this track section is attached to.
 | `Duration` | 0:1  | _xs:duration_ | Duration the passenger needs to travel through this track section.
 | `Length` | 0:1  | _siri:DistanceType_ | Length of this track section.
@@ -2304,6 +2294,26 @@ The element contains a _sequence_ of the following elements:
 | `System` | 1:1  | _xs:NMTOKEN_ | Code of the foreign referential system.
 | `Value` | 1:1  | _xs:NMTOKEN_ | Object code within this private/foreign system.
 |===
+
+
+=== The complex type `LinkProjectionStructure`
+
+An oriented correspondence from one LINK of a source layer, onto an entity in a target layer: e.g. LINK SEQUENCE.
+
+The element contains only one element:
+
+| `Position` | 2:*  | _siri:LocationStructure_ | Ordered list of locations representing the geogemtry of the link.
+
+
+
+=== The complex type `AreaStructure`
+
+Area described as a polygon.
+
+The element contains only one element:
+
+| `Points` | 3:*  | _siri:LocationStructure_ | Ordered list of geographic locations describing the polygon of the area.
+
 
 === The toplevel element `ParticipantRef`
 `ParticipantRef` | _siri:ParticipantRefStructure_ | 

--- a/docs/generated/OJP.html
+++ b/docs/generated/OJP.html
@@ -673,6 +673,8 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_simple_type_definitions_8">Simple type definitions</a></li>
 <li><a href="#_the_complex_type_code_errormessagestructure_code">The complex type <code>ErrorMessageStructure</code></a></li>
 <li><a href="#_the_complex_type_code_privatecodestructure_code">The complex type <code>PrivateCodeStructure</code></a></li>
+<li><a href="#_the_complex_type_code_linkprojectionstructure_code">The complex type <code>LinkProjectionStructure</code></a></li>
+<li><a href="#_the_complex_type_code_areastructure_code">The complex type <code>AreaStructure</code></a></li>
 <li><a href="#_the_toplevel_element_code_participantref_code">The toplevel element <code>ParticipantRef</code></a></li>
 <li><a href="#_the_complex_type_code_operatorfilterstructure_code">The complex type <code>OperatorFilterStructure</code></a></li>
 <li><a href="#_the_complex_type_code_productcategoryrefstructure_code">The complex type <code>ProductCategoryRefStructure</code></a></li>
@@ -2377,9 +2379,8 @@ The element contains a <em>sequence</em> of the following elements:</p>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Area</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">0:1</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Area covered by the locality described as a polygon.
-</p><p class="tableblock">The element contains only one element:</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Points</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>AreaStructure</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Area covered by the locality described as a polygon.</p></td>
 </tr>
 </tbody>
 </table>
@@ -5904,7 +5905,7 @@ The element contains a <em>sequence</em> of the following elements:</p>
 <p>The element contains only one element:</p>
 </div>
 <div class="paragraph">
-<p>| <code>TrackSection</code> | 1:*  | <em>TrackSectionStructure</em> | LINK PROJECTION on the infrastructure network of the TRIP LEG together with time information</p>
+<p>| <code>TrackSection</code> | 1:*  | <em>TrackSectionStructure</em> | LINK PROJECTION on the infrastructure network of the trip leg section together with time information.</p>
 </div>
 </div>
 <div class="sect2">
@@ -5936,33 +5937,26 @@ The element contains a <em>sequence</em> of the following elements:</p>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>LinkProjection</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">0:1</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">an oriented correspondence from one LINK of a source layer, onto an entity in a target layer: e.g. LINK SEQUENCE, COMPLEX FEATURE, within a defined TYPE OF PROJECTION
-</p><p class="tableblock">The element contains only one element:</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Position</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>LinkProjectionStructure</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">An oriented correspondence from one LINK of a source layer, onto an entity in a target layer: e.g. LINK SEQUENCE.</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2:*</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><em>siri:LocationStructure</em></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>RoadName</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">0:1</p></td>
-</tr>
-<tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><em>xs:string</em></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Name of the road this track section is attached to.</p></td>
+</tr>
+<tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Duration</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">0:1</p></td>
-</tr>
-<tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><em>xs:duration</em></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Duration the passenger needs to travel through this track section.</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Length</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">0:1</p></td>
 </tr>
 <tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Length</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0:1</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><em>siri:DistanceType</em></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Length of this track section.</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Extension</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">0:1</p></td>
 </tr>
 </tbody>
 </table>
@@ -7425,6 +7419,30 @@ The element contains a <em>sequence</em> of the following elements:</p>
 </tr>
 </tbody>
 </table>
+</div>
+<div class="sect2">
+<h3 id="_the_complex_type_code_linkprojectionstructure_code">The complex type <code>LinkProjectionStructure</code></h3>
+<div class="paragraph">
+<p>An oriented correspondence from one LINK of a source layer, onto an entity in a target layer: e.g. LINK SEQUENCE.</p>
+</div>
+<div class="paragraph">
+<p>The element contains only one element:</p>
+</div>
+<div class="paragraph">
+<p>| <code>Position</code> | 2:*  | <em>siri:LocationStructure</em> | Ordered list of locations representing the geogemtry of the link.</p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_the_complex_type_code_areastructure_code">The complex type <code>AreaStructure</code></h3>
+<div class="paragraph">
+<p>Area described as a polygon.</p>
+</div>
+<div class="paragraph">
+<p>The element contains only one element:</p>
+</div>
+<div class="paragraph">
+<p>| <code>Points</code> | 3:*  | <em>siri:LocationStructure</em> | Ordered list of geographic locations describing the polygon of the area.</p>
+</div>
 </div>
 <div class="sect2">
 <h3 id="_the_toplevel_element_code_participantref_code">The toplevel element <code>ParticipantRef</code></h3>


### PR DESCRIPTION
Introduced within OJP_Common.xsd the complex types AreaStructure and LinkProjectionStructure. Changed TopographicPlaceStructure.Area to type AreaStructure. Changed TrackSectionStructure.LinkProjection to type LinkProjectionStructure. Main reason was to eliminate structured elements without appropriate definitions of complex types for enabling automatic documentation.