### PR TITLE
Added service arrival and departure structures

### DIFF
--- a/OJP/OJP_JourneySupport.xsd
+++ b/OJP/OJP_JourneySupport.xsd
@@ -272,31 +272,37 @@
 			</xs:element>
 		</xs:sequence>
 	</xs:group>
+	<xs:complexType name="ServiceArrivalStructure">
+		<xs:annotation>
+			<xs:documentation>Arrival times of a service at a stop (group of attributes of TIMETABLED PASSING TIME, ESTIMATED PASSING TIME, OBSERVED PASSING TIME).</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:group ref="ServiceTimeGroup"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ServiceDepartureStructure">
+		<xs:annotation>
+			<xs:documentation>Departure times of a service at a stop (group of attributes of TIMETABLED PASSING TIME, ESTIMATED PASSING TIME, OBSERVED PASSING TIME).</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:group ref="ServiceTimeGroup"/>
+		</xs:sequence>
+	</xs:complexType>
 	<xs:complexType name="CallAtStopStructure">
 		<xs:annotation>
 			<xs:documentation>[same as CALL in SIRI] the meeting of a VEHICLE JOURNEY with a specific SCHEDULED STOP POINT </xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
 			<xs:group ref="StopPointGroup"/>
-			<xs:element name="ServiceArrival" minOccurs="0">
+			<xs:element name="ServiceArrival" type="ServiceArrivalStructure" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>Arrival times of the service at this stop ( group of attributes of TIMETABLED PASSING TIME, ESTIMATED PASSING TIME, OBSERVED PASSING TIME).</xs:documentation>
 				</xs:annotation>
-				<xs:complexType>
-					<xs:sequence>
-						<xs:group ref="ServiceTimeGroup"/>
-					</xs:sequence>
-				</xs:complexType>
 			</xs:element>
-			<xs:element name="ServiceDeparture" minOccurs="0">
+			<xs:element name="ServiceDeparture" type="ServiceDepartureStructure" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>Departure times of the service at this stop ( group of attributes of TIMETABLED PASSING TIME, ESTIMATED PASSING TIME, OBSERVED PASSING TIME).</xs:documentation>
 				</xs:annotation>
-				<xs:complexType>
-					<xs:sequence>
-						<xs:group ref="ServiceTimeGroup"/>
-					</xs:sequence>
-				</xs:complexType>
 			</xs:element>
 			<xs:group ref="StopCallStatusGroup"/>
 			<xs:element ref="SituationFullRef" minOccurs="0" maxOccurs="unbounded"/>

--- a/OJP/OJP_Trips.xsd
+++ b/OJP/OJP_Trips.xsd
@@ -519,25 +519,15 @@
 		</xs:annotation>
 		<xs:sequence>
 			<xs:group ref="StopPointGroup"/>
-			<xs:element name="ServiceArrival" minOccurs="0">
+			<xs:element name="ServiceArrival" type="ServiceArrivalStructure" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>describes the arrival situation a this leg board stop point (empty for first leg) ( group of attributes of TIMETABLED PASSING TIME, ESTIMATED PASSING TIME, OBSERVED PASSING TIME)</xs:documentation>
 				</xs:annotation>
-				<xs:complexType>
-					<xs:sequence>
-						<xs:group ref="ServiceTimeGroup"/>
-					</xs:sequence>
-				</xs:complexType>
 			</xs:element>
-			<xs:element name="ServiceDeparture">
+			<xs:element name="ServiceDeparture" type="ServiceDepartureStructure">
 				<xs:annotation>
 					<xs:documentation>describes the departure situation at this leg board stop point ( group of attributes of TIMETABLED PASSING TIME, ESTIMATED PASSING TIME, OBSERVED PASSING TIME)</xs:documentation>
 				</xs:annotation>
-				<xs:complexType>
-					<xs:sequence>
-						<xs:group ref="ServiceTimeGroup"/>
-					</xs:sequence>
-				</xs:complexType>
 			</xs:element>
 			<xs:element name="DistributorInterchangeId" type="xs:normalizedString" minOccurs="0">
 				<xs:annotation>
@@ -558,25 +548,15 @@
 		</xs:annotation>
 		<xs:sequence>
 			<xs:group ref="StopPointGroup"/>
-			<xs:element name="ServiceArrival">
+			<xs:element name="ServiceArrival" type="ServiceArrivalStructure">
 				<xs:annotation>
 					<xs:documentation>describes the arrival situation at the leg alight stop point ( group of attributes of TIMETABLED PASSING TIME, ESTIMATED PASSING TIME, OBSERVED PASSING TIME)</xs:documentation>
 				</xs:annotation>
-				<xs:complexType>
-					<xs:sequence>
-						<xs:group ref="ServiceTimeGroup"/>
-					</xs:sequence>
-				</xs:complexType>
 			</xs:element>
-			<xs:element name="ServiceDeparture" minOccurs="0">
+			<xs:element name="ServiceDeparture" type="ServiceDepartureStructure" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>describes the departure situation at this leg alight stop point (empty for last leg) ( group of attributes of TIMETABLED PASSING TIME, ESTIMATED PASSING TIME, OBSERVED PASSING TIME)</xs:documentation>
 				</xs:annotation>
-				<xs:complexType>
-					<xs:sequence>
-						<xs:group ref="ServiceTimeGroup"/>
-					</xs:sequence>
-				</xs:complexType>
 			</xs:element>
 			<xs:element name="FeederInterchangeId" type="xs:normalizedString" minOccurs="0">
 				<xs:annotation>
@@ -597,25 +577,15 @@
 		</xs:annotation>
 		<xs:sequence>
 			<xs:group ref="StopPointGroup"/>
-			<xs:element name="ServiceArrival">
+			<xs:element name="ServiceArrival" type="ServiceArrivalStructure">
 				<xs:annotation>
 					<xs:documentation>describes the arrival situation a this leg board stop point (empty for first leg) ( group of attributes of TIMETABLED PASSING TIME, ESTIMATED PASSING TIME, OBSERVED PASSING TIME)</xs:documentation>
 				</xs:annotation>
-				<xs:complexType>
-					<xs:sequence>
-						<xs:group ref="ServiceTimeGroup"/>
-					</xs:sequence>
-				</xs:complexType>
 			</xs:element>
-			<xs:element name="ServiceDeparture">
+			<xs:element name="ServiceDeparture" type="ServiceDepartureStructure">
 				<xs:annotation>
 					<xs:documentation>describes the departure situation at this leg board stop point ( group of attributes of TIMETABLED PASSING TIME, ESTIMATED PASSING TIME, OBSERVED PASSING TIME)</xs:documentation>
 				</xs:annotation>
-				<xs:complexType>
-					<xs:sequence>
-						<xs:group ref="ServiceTimeGroup"/>
-					</xs:sequence>
-				</xs:complexType>
 			</xs:element>
 			<xs:element name="MeetsViaRequest" type="xs:boolean" default="false" minOccurs="0">
 				<xs:annotation>

--- a/docs/generated/OJP.adoc
+++ b/docs/generated/OJP.adoc
@@ -1216,18 +1216,8 @@ The element contains a _sequence_ of the following elements:
 
 |===
 | `StopPointGroup` | 1:1 
-| `ServiceArrival` | 0:1  | describes the arrival situation a this leg board stop point (empty for first leg) ( group of attributes of TIMETABLED PASSING TIME, ESTIMATED PASSING TIME, OBSERVED PASSING TIME)
-
-The element contains only one element:
-
-| `ServiceTimeGroup` | 1:1 
-
-| `ServiceDeparture` | 1:1  | describes the departure situation at this leg board stop point ( group of attributes of TIMETABLED PASSING TIME, ESTIMATED PASSING TIME, OBSERVED PASSING TIME)
-
-The element contains only one element:
-
-| `ServiceTimeGroup` | 1:1 
-
+| `ServiceArrival` | 0:1  | _ServiceArrivalStructure_ | describes the arrival situation a this leg board stop point (empty for first leg) ( group of attributes of TIMETABLED PASSING TIME, ESTIMATED PASSING TIME, OBSERVED PASSING TIME)
+| `ServiceDeparture` | 1:1  | _ServiceDepartureStructure_ | describes the departure situation at this leg board stop point ( group of attributes of TIMETABLED PASSING TIME, ESTIMATED PASSING TIME, OBSERVED PASSING TIME)
 | `DistributorInterchangeId` | 0:1  | _xs:normalizedString_ | Interchange identifier of the distributing line/service at its boarding. This is not a reference. This identifier is used to recognize in a distributed environment (e.g. EU-Spirit), that two systems refer to the same line (or service) while using their own internal references. In EU-Spirit this is used to decide whether an interchange is in fact a stay-seated scanario (aka "line ID"). See https://eu-spirit.eu/
 | `MeetsViaRequest` | 0:1  | _xs:boolean_ | This stop fulfils one of the via requirements stated in the request data.
 | `StopCallStatusGroup` | 1:1 
@@ -1241,18 +1231,8 @@ The element contains a _sequence_ of the following elements:
 
 |===
 | `StopPointGroup` | 1:1 
-| `ServiceArrival` | 1:1  | describes the arrival situation at the leg alight stop point ( group of attributes of TIMETABLED PASSING TIME, ESTIMATED PASSING TIME, OBSERVED PASSING TIME)
-
-The element contains only one element:
-
-| `ServiceTimeGroup` | 1:1 
-
-| `ServiceDeparture` | 0:1  | describes the departure situation at this leg alight stop point (empty for last leg) ( group of attributes of TIMETABLED PASSING TIME, ESTIMATED PASSING TIME, OBSERVED PASSING TIME)
-
-The element contains only one element:
-
-| `ServiceTimeGroup` | 1:1 
-
+| `ServiceArrival` | 1:1  | _ServiceArrivalStructure_ | describes the arrival situation at the leg alight stop point ( group of attributes of TIMETABLED PASSING TIME, ESTIMATED PASSING TIME, OBSERVED PASSING TIME)
+| `ServiceDeparture` | 0:1  | _ServiceDepartureStructure_ | describes the departure situation at this leg alight stop point (empty for last leg) ( group of attributes of TIMETABLED PASSING TIME, ESTIMATED PASSING TIME, OBSERVED PASSING TIME)
 | `FeederInterchangeId` | 0:1  | _xs:normalizedString_ | Interchange identifier of the feeding line/service at its alighting. This is not a reference. This identifier is used to recognize in a distributed environment (e.g. EU-Spirit), that two systems refer to the same line (or service) while using their own internal references. In EU-Spirit this is used to decide whether an interchange is in fact a stay-seated scanario (aka "line ID"). See https://eu-spirit.eu/
 | `MeetsViaRequest` | 0:1  | _xs:boolean_ | This stop fulfils one of the via requirements stated in the request data.
 | `StopCallStatusGroup` | 1:1 
@@ -1266,18 +1246,8 @@ The element contains a _sequence_ of the following elements:
 
 |===
 | `StopPointGroup` | 1:1 
-| `ServiceArrival` | 1:1  | describes the arrival situation a this leg board stop point (empty for first leg) ( group of attributes of TIMETABLED PASSING TIME, ESTIMATED PASSING TIME, OBSERVED PASSING TIME)
-
-The element contains only one element:
-
-| `ServiceTimeGroup` | 1:1 
-
-| `ServiceDeparture` | 1:1  | describes the departure situation at this leg board stop point ( group of attributes of TIMETABLED PASSING TIME, ESTIMATED PASSING TIME, OBSERVED PASSING TIME)
-
-The element contains only one element:
-
-| `ServiceTimeGroup` | 1:1 
-
+| `ServiceArrival` | 1:1  | _ServiceArrivalStructure_ | describes the arrival situation a this leg board stop point (empty for first leg) ( group of attributes of TIMETABLED PASSING TIME, ESTIMATED PASSING TIME, OBSERVED PASSING TIME)
+| `ServiceDeparture` | 1:1  | _ServiceDepartureStructure_ | describes the departure situation at this leg board stop point ( group of attributes of TIMETABLED PASSING TIME, ESTIMATED PASSING TIME, OBSERVED PASSING TIME)
 | `MeetsViaRequest` | 0:1  | _xs:boolean_ | This stop fulfils one of the via requirements stated in the request data.
 | `StopCallStatusGroup` | 1:1 
 |===
@@ -1607,6 +1577,26 @@ The element contains a _sequence_ of the following elements:
 |===
 
 
+=== The complex type `ServiceArrivalStructure`
+
+Arrival times of a service at a stop (group of attributes of TIMETABLED PASSING TIME, ESTIMATED PASSING TIME, OBSERVED PASSING TIME).
+
+The element contains only one element:
+
+| `ServiceTimeGroup` | 1:1 
+
+
+
+=== The complex type `ServiceDepartureStructure`
+
+Departure times of a service at a stop (group of attributes of TIMETABLED PASSING TIME, ESTIMATED PASSING TIME, OBSERVED PASSING TIME).
+
+The element contains only one element:
+
+| `ServiceTimeGroup` | 1:1 
+
+
+
 === The complex type `CallAtStopStructure`
 
 [same as CALL in SIRI] the meeting of a VEHICLE JOURNEY with a specific SCHEDULED STOP POINT 
@@ -1614,18 +1604,8 @@ The element contains a _sequence_ of the following elements:
 
 |===
 | `StopPointGroup` | 1:1 
-| `ServiceArrival` | 0:1  | Arrival times of the service at this stop ( group of attributes of TIMETABLED PASSING TIME, ESTIMATED PASSING TIME, OBSERVED PASSING TIME).
-
-The element contains only one element:
-
-| `ServiceTimeGroup` | 1:1 
-
-| `ServiceDeparture` | 0:1  | Departure times of the service at this stop ( group of attributes of TIMETABLED PASSING TIME, ESTIMATED PASSING TIME, OBSERVED PASSING TIME).
-
-The element contains only one element:
-
-| `ServiceTimeGroup` | 1:1 
-
+| `ServiceArrival` | 0:1  | _ServiceArrivalStructure_ | Arrival times of the service at this stop ( group of attributes of TIMETABLED PASSING TIME, ESTIMATED PASSING TIME, OBSERVED PASSING TIME).
+| `ServiceDeparture` | 0:1  | _ServiceDepartureStructure_ | Departure times of the service at this stop ( group of attributes of TIMETABLED PASSING TIME, ESTIMATED PASSING TIME, OBSERVED PASSING TIME).
 | `StopCallStatusGroup` | 1:1 
 | `SituationFullRef` | 0:*  
 |===

--- a/docs/generated/OJP.html
+++ b/docs/generated/OJP.html
@@ -594,6 +594,8 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_the_code_timewindowgroup_code_group">The <code>TimeWindowGroup</code> group</a></li>
 <li><a href="#_the_code_servicetimegroup_code_group">The <code>ServiceTimeGroup</code> group</a></li>
 <li><a href="#_the_code_estimatedtimebandgroup_code_group">The <code>EstimatedTimeBandGroup</code> group</a></li>
+<li><a href="#_the_complex_type_code_servicearrivalstructure_code">The complex type <code>ServiceArrivalStructure</code></a></li>
+<li><a href="#_the_complex_type_code_servicedeparturestructure_code">The complex type <code>ServiceDepartureStructure</code></a></li>
 <li><a href="#_the_complex_type_code_callatstopstructure_code">The complex type <code>CallAtStopStructure</code></a></li>
 <li><a href="#_the_code_stopcallstatusgroup_code_group">The <code>StopCallStatusGroup</code> group</a></li>
 <li><a href="#_the_code_servicestatusgroup_code_group">The <code>ServiceStatusGroup</code> group</a></li>
@@ -4139,22 +4141,16 @@ The element contains a <em>sequence</em> of the following elements:</p>
 <td class="tableblock halign-left valign-top"><p class="tableblock">0:1</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">describes the arrival situation a this leg board stop point (empty for first leg) ( group of attributes of TIMETABLED PASSING TIME, ESTIMATED PASSING TIME, OBSERVED PASSING TIME)
-</p><p class="tableblock">The element contains only one element:</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>ServiceTimeGroup</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>ServiceArrivalStructure</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">describes the arrival situation a this leg board stop point (empty for first leg) ( group of attributes of TIMETABLED PASSING TIME, ESTIMATED PASSING TIME, OBSERVED PASSING TIME)</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">1:1</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>ServiceDeparture</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1:1</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">1:1</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">describes the departure situation at this leg board stop point ( group of attributes of TIMETABLED PASSING TIME, ESTIMATED PASSING TIME, OBSERVED PASSING TIME)
-</p><p class="tableblock">The element contains only one element:</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>ServiceTimeGroup</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">1:1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>ServiceDepartureStructure</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">describes the departure situation at this leg board stop point ( group of attributes of TIMETABLED PASSING TIME, ESTIMATED PASSING TIME, OBSERVED PASSING TIME)</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>DistributorInterchangeId</code></p></td>
@@ -4200,22 +4196,16 @@ The element contains a <em>sequence</em> of the following elements:</p>
 <td class="tableblock halign-left valign-top"><p class="tableblock">1:1</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">describes the arrival situation at the leg alight stop point ( group of attributes of TIMETABLED PASSING TIME, ESTIMATED PASSING TIME, OBSERVED PASSING TIME)
-</p><p class="tableblock">The element contains only one element:</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>ServiceTimeGroup</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>ServiceArrivalStructure</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">describes the arrival situation at the leg alight stop point ( group of attributes of TIMETABLED PASSING TIME, ESTIMATED PASSING TIME, OBSERVED PASSING TIME)</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">1:1</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>ServiceDeparture</code></p></td>
-</tr>
-<tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">0:1</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">describes the departure situation at this leg alight stop point (empty for last leg) ( group of attributes of TIMETABLED PASSING TIME, ESTIMATED PASSING TIME, OBSERVED PASSING TIME)
-</p><p class="tableblock">The element contains only one element:</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>ServiceTimeGroup</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">1:1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>ServiceDepartureStructure</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">describes the departure situation at this leg alight stop point (empty for last leg) ( group of attributes of TIMETABLED PASSING TIME, ESTIMATED PASSING TIME, OBSERVED PASSING TIME)</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>FeederInterchangeId</code></p></td>
@@ -4261,22 +4251,16 @@ The element contains a <em>sequence</em> of the following elements:</p>
 <td class="tableblock halign-left valign-top"><p class="tableblock">1:1</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">describes the arrival situation a this leg board stop point (empty for first leg) ( group of attributes of TIMETABLED PASSING TIME, ESTIMATED PASSING TIME, OBSERVED PASSING TIME)
-</p><p class="tableblock">The element contains only one element:</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>ServiceTimeGroup</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>ServiceArrivalStructure</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">describes the arrival situation a this leg board stop point (empty for first leg) ( group of attributes of TIMETABLED PASSING TIME, ESTIMATED PASSING TIME, OBSERVED PASSING TIME)</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">1:1</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>ServiceDeparture</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1:1</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">1:1</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">describes the departure situation at this leg board stop point ( group of attributes of TIMETABLED PASSING TIME, ESTIMATED PASSING TIME, OBSERVED PASSING TIME)
-</p><p class="tableblock">The element contains only one element:</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>ServiceTimeGroup</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">1:1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>ServiceDepartureStructure</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">describes the departure situation at this leg board stop point ( group of attributes of TIMETABLED PASSING TIME, ESTIMATED PASSING TIME, OBSERVED PASSING TIME)</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>MeetsViaRequest</code></p></td>
@@ -5275,6 +5259,30 @@ The element contains a <em>sequence</em> of the following elements:</p>
 </table>
 </div>
 <div class="sect2">
+<h3 id="_the_complex_type_code_servicearrivalstructure_code">The complex type <code>ServiceArrivalStructure</code></h3>
+<div class="paragraph">
+<p>Arrival times of a service at a stop (group of attributes of TIMETABLED PASSING TIME, ESTIMATED PASSING TIME, OBSERVED PASSING TIME).</p>
+</div>
+<div class="paragraph">
+<p>The element contains only one element:</p>
+</div>
+<div class="paragraph">
+<p>| <code>ServiceTimeGroup</code> | 1:1</p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_the_complex_type_code_servicedeparturestructure_code">The complex type <code>ServiceDepartureStructure</code></h3>
+<div class="paragraph">
+<p>Departure times of a service at a stop (group of attributes of TIMETABLED PASSING TIME, ESTIMATED PASSING TIME, OBSERVED PASSING TIME).</p>
+</div>
+<div class="paragraph">
+<p>The element contains only one element:</p>
+</div>
+<div class="paragraph">
+<p>| <code>ServiceTimeGroup</code> | 1:1</p>
+</div>
+</div>
+<div class="sect2">
 <h3 id="_the_complex_type_code_callatstopstructure_code">The complex type <code>CallAtStopStructure</code></h3>
 <div class="paragraph">
 <p>[same as CALL in SIRI] the meeting of a VEHICLE JOURNEY with a specific SCHEDULED STOP POINT
@@ -5295,22 +5303,16 @@ The element contains a <em>sequence</em> of the following elements:</p>
 <td class="tableblock halign-left valign-top"><p class="tableblock">0:1</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Arrival times of the service at this stop ( group of attributes of TIMETABLED PASSING TIME, ESTIMATED PASSING TIME, OBSERVED PASSING TIME).
-</p><p class="tableblock">The element contains only one element:</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>ServiceTimeGroup</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>ServiceArrivalStructure</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Arrival times of the service at this stop ( group of attributes of TIMETABLED PASSING TIME, ESTIMATED PASSING TIME, OBSERVED PASSING TIME).</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">1:1</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>ServiceDeparture</code></p></td>
-</tr>
-<tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">0:1</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Departure times of the service at this stop ( group of attributes of TIMETABLED PASSING TIME, ESTIMATED PASSING TIME, OBSERVED PASSING TIME).
-</p><p class="tableblock">The element contains only one element:</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>ServiceTimeGroup</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">1:1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>ServiceDepartureStructure</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Departure times of the service at this stop ( group of attributes of TIMETABLED PASSING TIME, ESTIMATED PASSING TIME, OBSERVED PASSING TIME).</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>StopCallStatusGroup</code></p></td>


### PR DESCRIPTION
Introduced within OJP_JourneySupport.xsd the complex types ServiceArrivalStructure and ServiceDepartureStructure. Changed within CallAtStopStructure, LegBoardStructure, LegAlightStructure, and LegIntermediateStructure the respective element ServiceArrival to the type ServiceArrivalStructure and the element ServiceDeparture to the type ServiceDepartureStructure. Main reason was to eliminate structured elements within an appropriate definition of a complex type, in order to enable automatic documentation generation.