### PR TITLE
Allows for level information on PathLinks

### DIFF
--- a/OJP_Trips.xsd
+++ b/OJP_Trips.xsd
@@ -795,29 +795,29 @@
 					<xs:documentation>Number how often the access feature occurs in this PathLink</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="FromLevel" type="LevelNameStructure" minOccurs="0">
+			<xs:element name="From" type="PathLinkEndStructure" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>Designations of the level where the PathLink starts.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="ToLevel" type="LevelNameStructure" minOccurs="0">
+			<xs:element name="To" type="PathLinkEndStructure" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>Designations of the level where the PathLink ends.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 		</xs:sequence>
 	</xs:complexType>
-	<xs:complexType name="LevelNameStructure">
+	<xs:complexType name="PathLinkEndStructure">
 		<xs:annotation>
 			<xs:documentation>Designations of a floor.</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
-			<xs:element name="PublicCode" type="xs:normalizedString" minOccurs="0">
+			<xs:element name="LevelPublicCode" type="xs:normalizedString" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>Public identifier of the level as found on elevators and signs.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="Name" type="InternationalTextStructure" minOccurs="0">
+			<xs:element name="LevelName" type="InternationalTextStructure" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>Official name of the level.</xs:documentation>
 				</xs:annotation>

--- a/OJP_Trips.xsd
+++ b/OJP_Trips.xsd
@@ -822,6 +822,11 @@
 					<xs:documentation>Official name of the level.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
+			<xs:element name="id" type="xs:normalizedString" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Id of the element at the From or To end of the PathLink (typically a PLACE).</xs:documentation>
+				</xs:annotation>
+			</xs:element>
 		</xs:sequence>
 	</xs:complexType>
 	<xs:annotation>

--- a/OJP_Trips.xsd
+++ b/OJP_Trips.xsd
@@ -777,12 +777,12 @@
 	</xs:simpleType>
 	<xs:complexType name="PathLinkStructure">
 		<xs:annotation>
-			<xs:documentation>[TMv6] a link within a PLACE of or between two PLACEs (that is STOP PLACEs, ACCESS SPACEs or QUAYs,BOARDING POSITIONs,, POINTs OF INTEREST etc or PATH JUNCTIONs) that represents a step in a possible route for pedestrians, cyclists or other out-of-vehicle passengers within or between a PLACE.</xs:documentation>
+			<xs:documentation>[TMv6] a link within a PLACE of or between two PLACEs (that is STOP PLACEs, ACCESS SPACEs or QUAYs,BOARDING POSITIONs, POINTs OF INTEREST etc or PATH JUNCTIONs) that represents a step in a possible route for pedestrians, cyclists or other out-of-vehicle passengers within or between a PLACE.</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
 			<xs:element name="Transition" type="TransitionEnumeration" minOccurs="0">
 				<xs:annotation>
-					<xs:documentation>Whether path is up down or level .</xs:documentation>
+					<xs:documentation>Whether path is up down or level.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="AccessFeatureType" type="AccessFeatureTypeEnumeration" minOccurs="0">
@@ -793,6 +793,33 @@
 			<xs:element name="Count" type="xs:positiveInteger" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>Number how often the access feature occurs in this PathLink</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="FromLevel" type="LevelNameStructure" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Designations of the level where the PathLink starts.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ToLevel" type="LevelNameStructure" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Designations of the level where the PathLink ends.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="LevelNameStructure">
+		<xs:annotation>
+			<xs:documentation>Designations of a floor.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="PublicCode" type="xs:normalizedString" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Public identifier of the level as found on elevators and signs.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Name" type="InternationalTextStructure" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Official name of the level.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 		</xs:sequence>


### PR DESCRIPTION
Allows for level information on PathLinks. This PR responds to #145.

#145 asks for more data to tell a passenger, for instance, to use an elevator leading from level "A" to level "U1". This is achieved by adding FromLevel, ToLevel, LevelNameStructure.

Typical attributes useful for guidance in that kind of use cases (example):
PathLink.Transition: down 
PathLink.AccessFeatureType: elevator
PathLink.FromLevel.PublicCode: A  (new)
PathLink.ToLevel.PublicCode: U1  (new)

Two other PRs related to this will follow soon - dealing with real-time information about access equipment (#194) and additional accessiblity information. 
