### PR TITLE
Add AccessFeatureStatus on PathLink to indicate a broken access equipment.

### DIFF
--- a/OJP_Trips.xsd
+++ b/OJP_Trips.xsd
@@ -775,14 +775,24 @@
 			<xs:enumeration value="downAndUp"/>
 		</xs:restriction>
 	</xs:simpleType>
+	<xs:simpleType name="EquipmentStatusEnumeration">
+		<xs:annotation>
+			<xs:documentation>Allowed values for status of EQUIPMENT.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="unknown"/>
+			<xs:enumeration value="available"/>
+			<xs:enumeration value="notAvailable"/>
+		</xs:restriction>
+	</xs:simpleType>
 	<xs:complexType name="PathLinkStructure">
 		<xs:annotation>
-			<xs:documentation>[TMv6] a link within a PLACE of or between two PLACEs (that is STOP PLACEs, ACCESS SPACEs or QUAYs,BOARDING POSITIONs,, POINTs OF INTEREST etc or PATH JUNCTIONs) that represents a step in a possible route for pedestrians, cyclists or other out-of-vehicle passengers within or between a PLACE.</xs:documentation>
+			<xs:documentation>[TMv6] a link within a PLACE of or between two PLACEs (that is STOP PLACEs, ACCESS SPACEs or QUAYs,BOARDING POSITIONs, POINTs OF INTEREST etc or PATH JUNCTIONs) that represents a step in a possible route for pedestrians, cyclists or other out-of-vehicle passengers within or between a PLACE.</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
 			<xs:element name="Transition" type="TransitionEnumeration" minOccurs="0">
 				<xs:annotation>
-					<xs:documentation>Whether path is up down or level .</xs:documentation>
+					<xs:documentation>Whether path is up down or level.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="AccessFeatureType" type="AccessFeatureTypeEnumeration" minOccurs="0">
@@ -793,6 +803,11 @@
 			<xs:element name="Count" type="xs:positiveInteger" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>Number how often the access feature occurs in this PathLink</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="AccessFeatureStatus" type="EquipmentStatusEnumeration" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Whether the access feature is available or out of service.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 		</xs:sequence>


### PR DESCRIPTION
AccessFeatureStatus on a PathLink to indicate a broken access equipment.

#194 asks for data to tell whether, e.g., an elevator is broken, but to nevertheless show the route so that the passenger knows that this route would exist but is currently not feasible.

EquipmentStatusEnumeration has been added from NeTEx to indicate the status of an access equipment. The following would indicate that the elevator is broken:

PathLink.AccessFeatureStatus: notAvailable  (new)
PathLink.AccessFeatureType: elevator

The broken elevator makes the complete TransferLeg unfeasible - this should be flagged in the TransferLeg (e.g., TransferLeg.Feasibility : accessEquipmentOutOfService) or/and at the level of the Trip. 
What solution would you prefer? 

To also handle the case that the TranferLeg is not feasible due to a SituationFull (can that happen?), this could be indicated by:
TransferLeg.Feasibility: seeSituations