### PR TITLE
Path to xsd corrected in xml examples

### DIFF
--- a/examples/functions/availability/AvailabilityRequest.xml
+++ b/examples/functions/availability/AvailabilityRequest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<OJP xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.siri.org.uk/siri" xmlns:ojp="http://www.vdv.de/ojp" version="1.1-dev" xsi:schemaLocation="http://www.siri.org.uk/siri ../../OJP.xsd">
+<OJP xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.siri.org.uk/siri" xmlns:ojp="http://www.vdv.de/ojp" version="1.1-dev" xsi:schemaLocation="http://www.siri.org.uk/siri ../../../OJP.xsd">
 	<OJPRequest>
 		<ServiceRequest>
 			<RequestTimestamp>2020-01-19T12:00:00Z</RequestTimestamp>

--- a/examples/functions/availability/AvailabilityRequest_1.xml
+++ b/examples/functions/availability/AvailabilityRequest_1.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ojp:OJPAvailabilityRequest xmlns:ojp="http://www.vdv.de/ojp" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.siri.org.uk/siri  ../../OJP.xsd">
+<ojp:OJPAvailabilityRequest xmlns:ojp="http://www.vdv.de/ojp" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.siri.org.uk/siri  ../../../OJP.xsd">
 	<siri:RequestTimestamp>2022-12-12T11:46:00Z</siri:RequestTimestamp>
 	<ojp:PublicTransport>
 		<ojp:PickUpLocation>

--- a/examples/functions/availability/AvailabilityRequest_2.xml
+++ b/examples/functions/availability/AvailabilityRequest_2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ojp:OJPAvailabilityRequest xmlns:ojp="http://www.vdv.de/ojp" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.siri.org.uk/siri  ../../OJP.xsd">
+<ojp:OJPAvailabilityRequest xmlns:ojp="http://www.vdv.de/ojp" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.siri.org.uk/siri  ../../../OJP.xsd">
 	<siri:RequestTimestamp>2022-12-12T11:46:00Z</siri:RequestTimestamp>
 	<ojp:PublicTransport>
 		<ojp:PickUpLocation>

--- a/examples/functions/availability/AvailabilityResponse notOK.xml
+++ b/examples/functions/availability/AvailabilityResponse notOK.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ojp:OJPAvailabilityDelivery xmlns:ojp="http://www.vdv.de/ojp" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.siri.org.uk/siri  ../../OJP.xsd">
+<ojp:OJPAvailabilityDelivery xmlns:ojp="http://www.vdv.de/ojp" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.siri.org.uk/siri  ../../../OJP.xsd">
 	<siri:ResponseTimestamp>2001-12-17T09:30:47Z</siri:ResponseTimestamp>
 	<siri:Status>false</siri:Status>
 	<siri:ErrorCondition>

--- a/examples/functions/availability/AvailabilityResponse_OK.xml
+++ b/examples/functions/availability/AvailabilityResponse_OK.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ojp:OJPAvailabilityDelivery xmlns:ojp="http://www.vdv.de/ojp" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.siri.org.uk/siri  ../../OJP.xsd">
+<ojp:OJPAvailabilityDelivery xmlns:ojp="http://www.vdv.de/ojp" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.siri.org.uk/siri  ../../../OJP.xsd">
 	<siri:ResponseTimestamp>2001-12-17T09:30:47Z</siri:ResponseTimestamp>
 	<ojp:AvailabilityResult>
 		<ojp:PublicTransport>

--- a/examples/functions/line/LineRequest.xml
+++ b/examples/functions/line/LineRequest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<OJP xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.siri.org.uk/siri" xmlns:ojp="http://www.vdv.de/ojp" version="1.1-dev" xsi:schemaLocation="http://www.siri.org.uk/siri ../../OJP.xsd">
+<OJP xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.siri.org.uk/siri" xmlns:ojp="http://www.vdv.de/ojp" version="1.1-dev" xsi:schemaLocation="http://www.siri.org.uk/siri ../../../OJP.xsd">
 	<OJPRequest>
 		<ServiceRequest>
 			<RequestTimestamp>2022-12-19T12:00:00Z</RequestTimestamp>

--- a/examples/functions/line/LineResponse.xml
+++ b/examples/functions/line/LineResponse.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<siri:OJP xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:siri="http://www.siri.org.uk/siri" xmlns:ojp="http://www.vdv.de/ojp" version="1.1-dev" xsi:schemaLocation="http://www.siri.org.uk/siri ../../OJP.xsd">
+<siri:OJP xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:siri="http://www.siri.org.uk/siri" xmlns:ojp="http://www.vdv.de/ojp" version="1.1-dev" xsi:schemaLocation="http://www.siri.org.uk/siri ../../../OJP.xsd">
 	<siri:OJPResponse>
 		<siri:ServiceDelivery>
 			<siri:ResponseTimestamp>2022-12-01T17:54:38Z</siri:ResponseTimestamp>


### PR DESCRIPTION
After the reorgnanisation the relative paths to the xsd in the xml were incorrect. This is now corrected.