### PR TITLE
Rename `suitableForHeavilyDisabled` to `suitableForSeverelyDisabled`

### DIFF
--- a/OJP/OJP_Trips.xsd
+++ b/OJP/OJP_Trips.xsd
@@ -1222,7 +1222,7 @@ Can only be used when both participants recognise the same schedule version. If 
 			<xs:enumeration value="automaticRamp"/>
 			<xs:enumeration value="suitableForWheelchairs"/>
 			<xs:enumeration value="suitableForUnassistedWheelchairs"/>
-			<xs:enumeration value="suitableForHeavilyDisabled"/>
+			<xs:enumeration value="suitableForSeverelyDisabled"/>
 			<xs:enumeration value="suitableForPushchairs"/>
 			<xs:enumeration value="suitableForBicycles"/>
 			<xs:enumeration value="tactilePlatformEdges"/>


### PR DESCRIPTION
"heavily disabled" is not a correct term to describe a person with severe disabilities, all major dictionaries use "severely disabled" instead.