### PR TITLE
Add example for line and operator filter in StopEventRequest

### DIFF
--- a/examples/basic/StopEventRequest-Filters.xml
+++ b/examples/basic/StopEventRequest-Filters.xml
@@ -23,6 +23,11 @@
 						</Line>
 						<Exclude>true</Exclude>
 					</LineFilter>
+					<OperatorFilter>
+						<Exclude>true</Exclude>
+						<OperatorRef>operator-1</OperatorRef>
+						<OperatorRef>operator-2</OperatorRef>
+					</OperatorFilter>
 					<StopEventType>both</StopEventType>
 					<IncludePreviousCalls>true</IncludePreviousCalls>
 					<IncludeOnwardCalls>true</IncludeOnwardCalls>

--- a/examples/basic/StopEventRequest-LineFilter.xml
+++ b/examples/basic/StopEventRequest-LineFilter.xml
@@ -17,17 +17,17 @@
 					<DepArrTime>2020-12-01T12:00:00Z</DepArrTime>
 				</Location>
 				<Params>
-					<StopEventType>both</StopEventType>
-					<IncludePreviousCalls>true</IncludePreviousCalls>
-					<IncludeOnwardCalls>true</IncludeOnwardCalls>
-					<IncludeOperatingDays>true</IncludeOperatingDays>
-					<UseRealtimeData>full</UseRealtimeData>
 					<LineFilter>
 						<Line>
 							<siri:LineRef>7311234</siri:LineRef>
 						</Line>
 						<Exclude>true</Exclude>
 					</LineFilter>
+					<StopEventType>both</StopEventType>
+					<IncludePreviousCalls>true</IncludePreviousCalls>
+					<IncludeOnwardCalls>true</IncludeOnwardCalls>
+					<IncludeOperatingDays>true</IncludeOperatingDays>
+					<UseRealtimeData>full</UseRealtimeData>
 				</Params>
 			</OJPStopEventRequest>
 		</siri:ServiceRequest>

--- a/examples/basic/StopEventRequest-LineFilter.xml
+++ b/examples/basic/StopEventRequest-LineFilter.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OJP xmlns="http://www.vdv.de/ojp" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.0" xsi:schemaLocation="http://www.vdv.de/ojp ../../OJP.xsd">
+	<OJPRequest>
+		<siri:ServiceRequest>
+			<siri:RequestTimestamp>2020-01-20T12:00:00Z</siri:RequestTimestamp>
+			<siri:RequestorRef>IRMA</siri:RequestorRef>
+			<OJPStopEventRequest>
+				<siri:RequestTimestamp>2020-01-20T12:00:00Z</siri:RequestTimestamp>
+				<siri:MessageIdentifier>756</siri:MessageIdentifier>
+				<Location xmlns:siri="http://www.siri.org.uk/siri">
+					<PlaceRef>
+						<StopPlaceRef>8530813</StopPlaceRef>
+						<Name>
+							<Text>Zürich Kreuzplatz</Text>
+						</Name>
+					</PlaceRef>
+					<DepArrTime>2020-12-01T12:00:00Z</DepArrTime>
+				</Location>
+				<Params>
+					<StopEventType>both</StopEventType>
+					<IncludePreviousCalls>true</IncludePreviousCalls>
+					<IncludeOnwardCalls>true</IncludeOnwardCalls>
+					<IncludeOperatingDays>true</IncludeOperatingDays>
+					<UseRealtimeData>full</UseRealtimeData>
+					<LineFilter>
+						<Line>
+							<siri:LineRef>7311234</siri:LineRef>
+						</Line>
+						<Exclude>true</Exclude>
+					</LineFilter>
+				</Params>
+			</OJPStopEventRequest>
+		</siri:ServiceRequest>
+	</OJPRequest>
+</OJP>


### PR DESCRIPTION
I'm familiarising myself with OJP but I'm a little puzzled about how to set a line filter in the `StopEventRequest`.

Intellij's autocomplete and the HTML documentation suggests that you can do it like in the example in this PR but xmllint and weirdly Intellij itself complain about it.

```
examples/basic/StopEventRequest-LineFilter.xml:25: element LineFilter: Schemas validity error : Element '{http://www.vdv.de/ojp}LineFilter': This element is not expected. Expected is one of ( {http://www.vdv.de/ojp}IncludePlacesContext, {http://www.vdv.de/ojp}IncludeSituationsContext, {http://www.vdv.de/ojp}IncludeStopHierarchy, {http://www.vdv.de/ojp}Extension ).
```

Is the below example correct?